### PR TITLE
Fixed a bug with Profiles

### DIFF
--- a/Data/Data.lua
+++ b/Data/Data.lua
@@ -9,21 +9,6 @@ ns.AddonTitle = ns.L["ADDON_TITLE"]
 ns.DefaultIcon = "Interface/Icons/inv_misc_bag_07_green"
 
 --------------------------------------------------------------------------------
--- Version
---------------------------------------------------------------------------------
-
-local function GetVersion()
-	local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata
-	local version = GetAddOnMetadata(ADDON_NAME, "Version")
-	if not version or version:find("@") then
-		return "Dev"
-	end
-	return version
-end
-
-ns.Version = GetVersion()
-
---------------------------------------------------------------------------------
 -- Links
 --------------------------------------------------------------------------------
 

--- a/Data/Default-Settings.lua
+++ b/Data/Default-Settings.lua
@@ -5,19 +5,36 @@ local _, ns = ...
 --------------------------------------------------------------------------------
 
 --[[
-    AceDB-3.0 defaults. Every user setting lives under profile; AceDB applies
-    these via metatables (no hand-rolled merge, and explicit false survives).
-    The global subtable holds only the minimap button position, which is
-    profile-independent so switching or resetting a profile never moves it.
+    AceDB-3.0 defaults. AceDB applies these via metatables (no hand-rolled merge,
+    and explicit false survives).
+
+    Only the ignore list is profile-scoped, and it is stored per character inside
+    the profile: profile.ignoreLists is keyed by ns.db.keys.char (see
+    ns:GetIgnoreList), so every toon keeps its own list while a single shared
+    "Default" profile holds them all. Switching profiles swaps the whole set of
+    per-toon lists -- e.g. a "Farming" profile carries its own toon lists.
+
+    Everything else lives under global: account-wide, identical on every toon,
+    and untouched by profile switches. minimap is global too, so switching or
+    resetting a profile never moves the button.
 ]]
 ns.DATABASE_DEFAULTS = {
 	profile = {
-		showWelcome = true,
-		autoVendEnabled = false,
-		autoVendMessagesEnabled = true,
-		ignoreList = {},
+		ignoreLists = {},
 	},
 	global = {
+		showWelcome = true,
+		tooltipWarningEnabled = true,
+		autoVendEnabled = true,
+		autoVendMessagesEnabled = true,
+		autoVendSummaryEnabled = true,
+		bagsFullNudgeEnabled = false,
+		bagsFullThreshold = 4,
+		safetyEnabled = false,
+		safetyQuest = true,
+		safetyConsumable = false,
+		safetyWhite = false,
+		safetyGray = false,
 		minimap = {},
 	},
 }

--- a/Deferred — Magic Eraser Core.lua Split.md
+++ b/Deferred — Magic Eraser Core.lua Split.md
@@ -1,0 +1,74 @@
+# Deferred — Magic Eraser `Core.lua` Split
+
+A parked, ready-to-run task. `Features/Core.lua` has grown large; this splits its two
+biggest permanent chunks into their own feature files, leaving Core as the
+state + saved-variable lifecycle + event dispatcher spine the Style Guide describes.
+Run it when the maintainer decides Core is due for trimming — **not** as part of any
+scheduled review pass. Era only; there is no other client to touch.
+
+A matching `DESIGN NOTE` comment lives at the top of `Features/Core.lua`; delete it as
+part of executing this split.
+
+## Preconditions
+
+- Do the `Core.lua` comment-cleanup pass first (it may shrink Core enough that only one
+  extraction, or none, is needed — reassess after cleaning).
+- This split is independent of the dated migration blocks in `ns:OnPlayerLogin`. Those
+  stay in Core and self-remove by 2026-10-11; do not move them, and do not wait for them.
+
+## Prompt
+
+```
+Split Magic Eraser Features/Core.lua into feature files. Work only in the _classic_era_
+install. Change structure, not behavior. Rely on the Style Guide and README-Technical.md
+already describing this architecture.
+
+Create Features/Eraser.lua and move these out of Core.lua, in order, preserving comments:
+the scan cache locals (cachedItem, isCacheValid, cachedReclaimSlots/Items/Value), the
+retry machinery (MAX_SCAN_RETRIES, scanRetries, retryPending, inScanRetry), ns:InvalidateCache,
+ScheduleScanRetry, ns:GetItemDeleteReason, isBetterDeletionCandidate, ns:FindItemToDelete,
+ns:GetReclaimSummary, SAFETY_REASON_KEYS, ns:NeedsSafetyConfirm, the
+StaticPopupDialogs["MAGICERASER_CONFIRM_ERASE"] registration, ns:PerformErase, ns:RunEraser.
+Declare Eraser.lua's own upvalue locals at its top (GetContainerNumSlots, GetContainerItemInfo,
+PickupContainerItem via C_Container; format/ipairs) like Auto-Vend.lua does.
+
+Create Features/Bag-Warnings.lua and move: lastNudgeFree, CountFreeSlots, IsBagWindowOpen,
+ns:CheckBagsFullNudge, and ns:OnMailClosed. Declare its own local GetContainerNumFreeSlots.
+Because Core's ns:OnBagUpdateDelayed still gates the nudge on the bag window being closed,
+expose IsBagWindowOpen as ns:IsBagWindowOpen so that handler can call it; update the call site.
+
+Leave in Core.lua: locals it still uses, GetVersion/ns.Version, the ignore-list functions,
+db init and all migrations in ns:OnPlayerLogin, ns:OnDatabaseReset, ns:OnProfileSwitched,
+ns:OnPlayerLevelUp, ns:OnBagUpdateDelayed, ns:OnQuestTurnedIn, ns.EVENT_NAMES, EVENT_HANDLERS,
+and the dispatcher frame + registration loop. Do not change the dispatcher — handlers resolve
+by name at fire time, so moved handlers just need their file loaded after Core.
+
+Wire both new files into MagicEraser.toc in the "# Magic Eraser" block, after Features/Core.lua
+and before the Options files. Order within the feature files does not matter for dispatch, but
+keep Core.lua first. Delete the DESIGN NOTE block at the top of Core.lua.
+
+Update README-Technical.md: add both files to the File Map, and repoint any architecture prose
+that says these live in Core.lua.
+
+Verify: luac -p every moved/edited Lua file; grep to confirm no dangling references to moved
+file-local symbols remain in Core.lua; then load the add-on in-game (Classic Era) and confirm
+the minimap tooltip, an erase, and a bag-space warning all still work.
+```
+
+## Wiring gotchas (why the prompt is worded as it is)
+
+- **File-local symbols travel with their callers.** `cachedItem`, `isCacheValid`, the reclaim
+  totals, the retry flags, `isBetterDeletionCandidate`, `ScheduleScanRetry`, and
+  `SAFETY_REASON_KEYS` are only read by functions moving to `Eraser.lua`, so they move as a unit
+  and nothing in Core references them afterward. Confirm with a grep.
+- **Each file declares its own `C_Container` upvalues.** Core caches `GetContainerNumSlots` /
+  `GetContainerItemInfo` at its top; the moved scanners need their own copies (Auto-Vend already
+  does this). Core still uses `GetContainerNumSlots` in `ns:OnQuestTurnedIn`, so keep its locals.
+- **`IsBagWindowOpen` is the one cross-file call.** It currently gates `ns:OnBagUpdateDelayed`
+  (stays in Core) but logically belongs with the warnings. Promote it to `ns:IsBagWindowOpen`
+  so both `Core` (bag-update gate) and `Bag-Warnings` (its own use) can call it.
+- **No dispatcher edits.** `ns.EVENT_NAMES` and `EVENT_HANDLERS` stay in Core. `OnMailClosed`
+  moving to `Bag-Warnings.lua` is exactly the Auto-Vend pattern (`OnMerchantShow` etc. already
+  live outside Core); it works because the handler is resolved as `ns[handlerName]` at fire time.
+- **Load order.** Feature files must load after `Core.lua` (which defines the dispatcher and
+  `ns.db` lifecycle) — the TOC already lists Core first; keep it there.

--- a/Features/Announcements.lua
+++ b/Features/Announcements.lua
@@ -1,17 +1,15 @@
 local _, ns = ...
+local GetColor = ns.GetColor
 
 --------------------------------------------------------------------------------
 -- Messaging
 --------------------------------------------------------------------------------
 
 --[[
-    Player-only print. Branded colors, no target marker: the add-on name in
-    C_INFO, the // separator in C_SEPARATOR, the body in C_TEXT -- all applied
-    here via ns.BrandPrefix so locale strings stay clean. Magic Eraser sends no
-    cross-player chat, so there is no Announce/whisper path.
-
-    Format: |cff[INFO]Add-on Name|r |cff[SEPARATOR]//|r |cff[TEXT]Message|r
+    Player-only branded print via ns.BrandPrefix (built in Utilities, so locale
+    strings stay clean). Magic Eraser sends no cross-player chat, so there is no
+    Announce/whisper path.
 ]]
 function ns:PrintMessage(message)
-	print(ns.BrandPrefix .. ns.GetColor("TEXT") .. message .. "|r")
+	print(ns.BrandPrefix .. GetColor("TEXT") .. message .. "|r")
 end

--- a/Features/Auto-Vend.lua
+++ b/Features/Auto-Vend.lua
@@ -41,12 +41,23 @@ local vendPasses = 0
 local announcedSales = {}
 
 --[[
+    Per-visit totals for summary mode. Accrued for every newly announced sale
+    regardless of the Verbose/Summary setting, so flipping the dropdown
+    mid-visit still produces a correct closing line. Reset in StartVending
+    alongside announcedSales, and flushed in OnMerchantClosed.
+]]
+
+local summaryCount = 0
+local summaryValue = 0
+
+--[[
     Single guard for all Auto-Vend chat output. Disabling Auto-Vend messages
-    silences the deferred-combat notice and the per-item sale lines alike.
+    silences the deferred-combat notice, the per-item sale lines, and the
+    per-visit summary line alike.
 ]]
 
 local function PrintVendMessage(message)
-	if ns.db and ns.db.profile.autoVendMessagesEnabled then
+	if ns.db and ns.db.global.autoVendMessagesEnabled then
 		ns:PrintMessage(message)
 	end
 end
@@ -115,8 +126,12 @@ local function ProcessSellQueue()
 		local saleKey = string.format("%d:%d:%d", item.bag, item.slot, item.itemId)
 		if not announcedSales[saleKey] then
 			announcedSales[saleKey] = true
-			local stackString = (item.count > 1) and string.format(" x%d", item.count) or ""
-			PrintVendMessage(string.format(L["SOLD_ITEM"], item.link, stackString, ns:FormatCurrency(item.value)))
+			summaryCount = summaryCount + item.count
+			summaryValue = summaryValue + item.value
+			if not (ns.db and ns.db.global.autoVendSummaryEnabled) then
+				local stackString = (item.count > 1) and string.format(" x%d", item.count) or ""
+				PrintVendMessage(string.format(L["SOLD_ITEM"], item.link, stackString, ns:FormatCurrency(item.value)))
+			end
 		end
 	end
 
@@ -194,6 +209,8 @@ local function StartVending()
 	scanRetries = 0
 	vendPasses = 0
 	wipe(announcedSales)
+	summaryCount = 0
+	summaryValue = 0
 	ScanAndVend()
 end
 
@@ -209,7 +226,7 @@ end
 ]]
 
 function ns:OnMerchantShow()
-	if not (ns.db and ns.db.profile.autoVendEnabled) then
+	if not (ns.db and ns.db.global.autoVendEnabled) then
 		return
 	end
 
@@ -231,9 +248,29 @@ function ns:OnMerchantShow()
 end
 
 function ns:OnMerchantClosed()
+	--[[
+	    Summary mode prints one line per merchant visit, so closing the window
+	    is the flush point. Routed through PrintVendMessage so the Enable
+	    Auto-Vend Messages toggle silences it like all other vend output.
+	]]
+	if ns.db and ns.db.global.autoVendSummaryEnabled and summaryCount > 0 then
+		PrintVendMessage(
+			string.format(L["SOLD_SUMMARY"], ns:FormatCommaNumber(summaryCount), ns:FormatCurrency(summaryValue))
+		)
+	end
+	summaryCount = 0
+	summaryValue = 0
+
 	isSelling = false
 	vendPending = false
 	wipe(sellQueue)
+
+	--[[
+	    Bag-space warnings are suppressed while the merchant window is open (see
+	    OnBagUpdateDelayed in Core), since selling churns free slots. Re-check on
+	    close so the warning reflects where the bags landed after this visit.
+	]]
+	ns:CheckBagsFullNudge()
 end
 
 --[[
@@ -248,7 +285,7 @@ function ns:OnCombatEnded()
 	end
 	vendPending = false
 
-	if ns.db and ns.db.profile.autoVendEnabled and MerchantFrame and MerchantFrame:IsShown() then
+	if ns.db and ns.db.global.autoVendEnabled and MerchantFrame and MerchantFrame:IsShown() then
 		StartVending()
 	end
 end

--- a/Features/Core.lua
+++ b/Features/Core.lua
@@ -1,28 +1,87 @@
 local ADDON_NAME, ns = ...
 local L = ns.L
 
+--[[
+    DESIGN NOTE -- planned Core split (deferred; do not action inline). This file
+    is large. When it is time to trim it, extract two permanent feature files --
+    matching the "one file per feature" model and the Auto-Vend precedent -- and
+    leave Core as the state + lifecycle + dispatcher spine:
+      * Eraser.lua       -- scan cache, retry machinery, GetItemDeleteReason,
+                            ranking, the safety popup, PerformErase / RunEraser.
+      * Bag-Warnings.lua -- CountFreeSlots, IsBagWindowOpen, CheckBagsFullNudge,
+                            and the OnMailClosed handler.
+    The dated migration blocks stay here; they self-remove by 2026-10-11. Full
+    runnable prompt: Add-on Creation Factory / "Deferred -- Magic Eraser Core.lua
+    Split.md".
+]]
+
 --------------------------------------------------------------------------------
 -- Locals
 --------------------------------------------------------------------------------
 
 local GetContainerNumSlots = C_Container.GetContainerNumSlots
 local GetContainerItemInfo = C_Container.GetContainerItemInfo
+local GetContainerNumFreeSlots = C_Container.GetContainerNumFreeSlots
 local PickupContainerItem = C_Container.PickupContainerItem
 local format, ipairs = string.format, ipairs
+
+--------------------------------------------------------------------------------
+-- Version
+--------------------------------------------------------------------------------
+
+local function GetVersion()
+	local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata
+	local version = GetAddOnMetadata(ADDON_NAME, "Version")
+	if not version or version:find("@") then
+		return "Dev"
+	end
+	return version
+end
+
+ns.Version = GetVersion()
 
 --------------------------------------------------------------------------------
 -- Ignore List
 --------------------------------------------------------------------------------
 
+--[[
+    The ignore list is the one per-character setting. It lives inside the profile
+    but keyed by character (ns.db.keys.char = "Name - Realm"), so each toon has
+    its own list within whatever profile is active, and switching profiles swaps
+    the whole set. The bucket is created on first use, so a brand-new toon simply
+    starts empty. Returns nil only before the database exists.
+]]
+function ns:GetIgnoreList()
+	if not ns.db then
+		return nil
+	end
+	local ignoreLists = ns.db.profile.ignoreLists
+	if type(ignoreLists) ~= "table" then
+		ignoreLists = {}
+		ns.db.profile.ignoreLists = ignoreLists
+	end
+	local charKey = ns.db.keys.char
+	local list = ignoreLists[charKey]
+	if not list then
+		list = {}
+		ignoreLists[charKey] = list
+	end
+	return list
+end
+
 function ns:IsIgnored(itemId)
-	return ns.db and ns.db.profile.ignoreList[itemId]
+	local ignoreList = ns:GetIgnoreList()
+	return ignoreList and ignoreList[itemId]
 end
 
 function ns:ToggleIgnore(itemId)
 	if not itemId then
 		return
 	end
-	local ignoreList = ns.db.profile.ignoreList
+	local ignoreList = ns:GetIgnoreList()
+	if not ignoreList then
+		return
+	end
 	if ignoreList[itemId] then
 		ignoreList[itemId] = nil
 	else
@@ -33,7 +92,10 @@ function ns:ToggleIgnore(itemId)
 end
 
 function ns:ClearIgnoreList()
-	wipe(ns.db.profile.ignoreList)
+	local ignoreList = ns:GetIgnoreList()
+	if ignoreList then
+		wipe(ignoreList)
+	end
 	ns:InvalidateCache()
 	ns:RefreshDisplay()
 end
@@ -44,6 +106,17 @@ end
 
 local cachedItem = nil
 local isCacheValid = false
+
+--[[
+    Running totals for the tooltip's Clutter Report, populated as a side effect
+    of FindItemToDelete's single bag scan so the summary shares the candidate
+    cache's lifecycle -- one scan feeds both the lowest-value pick and the
+    report, and both go stale together on InvalidateCache. Slots counts bag slots
+    freed; items counts stacked quantity (a stack of 5 is one slot, five items).
+]]
+local cachedReclaimSlots = 0
+local cachedReclaimItems = 0
+local cachedReclaimValue = 0
 
 --[[
     Cold item-data misses reschedule a rescan. Without a cap, an item whose
@@ -60,6 +133,9 @@ local inScanRetry = false
 function ns:InvalidateCache()
 	isCacheValid = false
 	cachedItem = nil
+	cachedReclaimSlots = 0
+	cachedReclaimItems = 0
+	cachedReclaimValue = 0
 	if not inScanRetry then
 		scanRetries = 0
 	end
@@ -124,6 +200,7 @@ function ns:FindItemToDelete()
 	end
 
 	local best = nil
+	local reclaimSlots, reclaimItems, reclaimValue = 0, 0, 0
 	local _, playerClass = UnitClass("player")
 	local isDataMissing = false
 	local classReagentExclusions = (ns.ClassReagentExclusions and ns.ClassReagentExclusions[playerClass]) or {}
@@ -151,6 +228,10 @@ function ns:FindItemToDelete()
 						local deleteReason = self:GetItemDeleteReason(itemId, rarity, sellPrice, requiredLevel)
 
 						if deleteReason then
+							-- Slots counts one per qualifying slot; items counts stacked quantity.
+							reclaimSlots = reclaimSlots + 1
+							reclaimItems = reclaimItems + count
+							reclaimValue = reclaimValue + totalValue
 							local candidate = {
 								link = itemInfo.hyperlink,
 								itemId = itemId,
@@ -176,13 +257,119 @@ function ns:FindItemToDelete()
 	end
 
 	cachedItem = best
+	cachedReclaimSlots = reclaimSlots
+	cachedReclaimItems = reclaimItems
+	cachedReclaimValue = reclaimValue
 	isCacheValid = true
 	return best
+end
+
+--[[
+    Totals for the tooltip's Clutter Report: slots freed, item quantity, and total
+    value. FindItemToDelete populates these as a side effect of its scan, so
+    callers must have called it first this cache cycle (the tooltip does, just
+    above where it reads this).
+]]
+function ns:GetReclaimSummary()
+	return cachedReclaimSlots or 0, cachedReclaimItems or 0, cachedReclaimValue or 0
 end
 
 --------------------------------------------------------------------------------
 -- Deletion
 --------------------------------------------------------------------------------
+
+--[[
+    Safety Guard. Maps each delete reason to its opt-in confirmation toggle. When
+    the guard is on and the matching per-reason toggle is set, erasing that item
+    pops a confirmation first. "White vendor-quality" maps to the curated
+    equipment reason; the four reasons GetItemDeleteReason returns line up 1:1
+    with the four toggles.
+]]
+local SAFETY_REASON_KEYS = {
+	quest = "safetyQuest",
+	consumable = "safetyConsumable",
+	equipment = "safetyWhite",
+	gray = "safetyGray",
+}
+
+function ns:NeedsSafetyConfirm(item)
+	if not (item and ns.db and ns.db.global.safetyEnabled) then
+		return false
+	end
+	local key = SAFETY_REASON_KEYS[item.deleteReason]
+	return (key and ns.db.global[key]) and true or false
+end
+
+--[[
+    Confirmation dialog for guarded erases. The candidate is passed as the
+    dialog's data so each showing acts on the exact item the player saw, and
+    PerformErase re-validates the slot before deleting. preferredIndex = 3 avoids
+    tainting the shared dialog stack.
+]]
+StaticPopupDialogs["MAGICERASER_CONFIRM_ERASE"] = {
+	text = L["CONFIRM_ERASE"],
+	button1 = YES,
+	button2 = NO,
+	OnAccept = function(_, data)
+		if data then
+			ns:PerformErase(data)
+		end
+	end,
+	timeout = 0,
+	whileDead = true,
+	hideOnEscape = true,
+	showAlert = true,
+	preferredIndex = 3,
+}
+
+--[[
+    Actually erase the item: pick it up and delete it from the cursor. The
+    cursor's item id is re-checked against the candidate so a slot that shifted
+    (e.g. while a confirmation was open) aborts instead of deleting the wrong
+    thing. Re-guards combat because a safety confirmation can span the moment
+    combat begins.
+]]
+function ns:PerformErase(item)
+	if InCombatLockdown() then
+		self:PrintMessage(L["COMBAT_LOCKOUT"])
+		return
+	end
+
+	if CursorHasItem() then
+		ClearCursor()
+	end
+	PickupContainerItem(item.bag, item.slot)
+
+	local cursorType, cursorItemId = GetCursorInfo()
+	if cursorType == "item" and cursorItemId == item.itemId then
+		DeleteCursorItem()
+		PlaySound(5156)
+
+		local stackString = (item.count > 1) and format(" x%d", item.count) or ""
+
+		local valueString
+		if item.deleteReason == "quest" then
+			valueString = L["ERASED_QUEST_SUFFIX"]
+		elseif item.value > 0 then
+			valueString = format(L["ERASED_VALUE_SUFFIX"], ns:FormatCurrency(item.value))
+		else
+			valueString = ""
+		end
+
+		self:PrintMessage(format(L["ERASED_ITEM"], item.link, stackString, valueString))
+
+		ns:InvalidateCache()
+		C_Timer.After(0.2, function()
+			ns:RefreshDisplay()
+		end)
+		return
+	else
+		self:PrintMessage(L["CURSOR_TOO_FAST"])
+		ClearCursor()
+	end
+
+	ns:RefreshDisplay()
+end
 
 function ns:RunEraser()
 	if InCombatLockdown() then
@@ -192,44 +379,18 @@ function ns:RunEraser()
 
 	local item = self:FindItemToDelete()
 
-	if item then
-		if CursorHasItem() then
-			ClearCursor()
-		end
-		PickupContainerItem(item.bag, item.slot)
-
-		local cursorType, cursorItemId = GetCursorInfo()
-		if cursorType == "item" and cursorItemId == item.itemId then
-			DeleteCursorItem()
-			PlaySound(5156)
-
-			local stackString = (item.count > 1) and format(" x%d", item.count) or ""
-
-			local valueString
-			if item.deleteReason == "quest" then
-				valueString = L["ERASED_QUEST_SUFFIX"]
-			elseif item.value > 0 then
-				valueString = format(L["ERASED_VALUE_SUFFIX"], ns:FormatCurrency(item.value))
-			else
-				valueString = ""
-			end
-
-			self:PrintMessage(format(L["ERASED_ITEM"], item.link, stackString, valueString))
-
-			ns:InvalidateCache()
-			C_Timer.After(0.2, function()
-				ns:RefreshDisplay()
-			end)
-			return
-		else
-			self:PrintMessage(L["CURSOR_TOO_FAST"])
-			ClearCursor()
-		end
-	else
+	if not item then
 		self:PrintMessage(L["BAGS_CLEAN_SHORT"] .. " " .. L["BAGS_CLEAN_HINT"])
+		ns:RefreshDisplay()
+		return
 	end
 
-	ns:RefreshDisplay()
+	if ns:NeedsSafetyConfirm(item) then
+		local stackString = (item.count > 1) and format(" x%d", item.count) or ""
+		StaticPopup_Show("MAGICERASER_CONFIRM_ERASE", item.link, stackString, item)
+	else
+		ns:PerformErase(item)
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -252,6 +413,7 @@ ns.EVENT_NAMES = {
 	"QUEST_TURNED_IN",
 	"MERCHANT_SHOW",
 	"MERCHANT_CLOSED",
+	"MAIL_CLOSED",
 	"PLAYER_REGEN_ENABLED",
 }
 
@@ -262,10 +424,81 @@ local EVENT_HANDLERS = {
 	QUEST_TURNED_IN = "OnQuestTurnedIn",
 	MERCHANT_SHOW = "OnMerchantShow",
 	MERCHANT_CLOSED = "OnMerchantClosed",
+	MAIL_CLOSED = "OnMailClosed",
 	PLAYER_REGEN_ENABLED = "OnCombatEnded",
 }
 
 local updatePending = false
+
+--[[
+    Free-slot count at the last bag-space warning, so we don't reprint the same
+    number twice in a row. BAG_UPDATE_DELAYED can fire more than once for a single
+    purchase, and the 0.1s debounce only coalesces ones close together; this keeps
+    the countdown to one line per slot lost. Reset when free climbs back above the
+    threshold so re-entering the warning zone warns again. Runtime-only.
+
+    Primed to the current free count at login (see OnPlayerLogin): the client
+    fires a BAG_UPDATE_DELAYED burst as it populates bags on load, and we don't
+    want that to warn about bag space you arrived with -- only about slots lost
+    while playing. Seeding the baseline makes the login burst a no-op (free is
+    unchanged from the seed) so the first real warning waits for a real change.
+]]
+local lastNudgeFree = nil
+
+local function CountFreeSlots()
+	local free = 0
+	for bag = 0, 4 do
+		-- Specialty bags (quiver, soul, profession) are excluded: ordinary loot can't go there.
+		local bagFree, bagFamily = GetContainerNumFreeSlots(bag)
+		if (bagFamily or 0) == 0 then
+			free = free + (bagFree or 0)
+		end
+	end
+	return free
+end
+
+--[[
+    A merchant or mailbox visit is exactly when bags churn hardest -- selling
+    junk frees slots, buying and looting mail fills them -- so the countdown
+    would fire a burst of noise that is stale the moment the window closes. We
+    suppress it while either window is open (checked live rather than via a
+    tracked flag so it stays correct even if a SHOW event is missed) and re-check
+    once on close, so the warning reflects where the bags actually landed.
+]]
+local function IsBagWindowOpen()
+	return (MerchantFrame and MerchantFrame:IsShown()) or (MailFrame and MailFrame:IsShown()) or false
+end
+
+--[[
+    Bag-space warning. Purely a free-space alert -- it never deletes and does not
+    care whether there is anything erasable. Shared by the debounced bag update
+    (which gates it on no bag window being open) and the merchant/mailbox close
+    handlers (which fire it once the churn has settled). The lastNudgeFree dedup
+    means the close-fire only prints when the count actually changed from the
+    last line shown, so opening and closing a window without touching the bags
+    stays quiet.
+]]
+function ns:CheckBagsFullNudge()
+	if not (ns.db and ns.db.global.bagsFullNudgeEnabled) then
+		return
+	end
+
+	local free = CountFreeSlots()
+	if free > ns.db.global.bagsFullThreshold then
+		lastNudgeFree = nil
+	elseif free ~= lastNudgeFree then
+		lastNudgeFree = free
+		local message
+		if free == 0 then
+			message = L["BAGS_FULL"]
+		elseif free == 1 then
+			message = L["BAGS_FULL_NUDGE_ONE"]
+		else
+			message = string.format(L["BAGS_FULL_NUDGE"], free)
+		end
+		ns:PrintMessage(message)
+	end
+end
 
 function ns:OnPlayerLogin()
 	--[[
@@ -313,44 +546,206 @@ function ns:OnPlayerLogin()
 
 	ns.db = LibStub("AceDB-3.0"):New("MagicEraserDB", ns.DATABASE_DEFAULTS, true)
 
+	local global = ns.db.global
 	local profile = ns.db.profile
+	local charKey = ns.db.keys.char
+
+	--[[
+	    Apply the captured pre-AceDB values to their current homes: settings are
+	    account-wide now, so they go to global; the minimap seed goes to
+	    global.minimap; the per-character ignore list is folded in by the
+	    per-toon seeding below.
+	]]
 	if legacyShowWelcome ~= nil then
-		profile.showWelcome = legacyShowWelcome
+		global.showWelcome = legacyShowWelcome
 	end
 	if legacyAutoVend ~= nil then
-		profile.autoVendEnabled = legacyAutoVend
+		global.autoVendEnabled = legacyAutoVend
 	end
 	if legacyAutoVendMessages ~= nil then
-		profile.autoVendMessagesEnabled = legacyAutoVendMessages
-	end
-	if legacyIgnoreList then
-		for itemId in pairs(legacyIgnoreList) do
-			profile.ignoreList[itemId] = true
-		end
+		global.autoVendMessagesEnabled = legacyAutoVendMessages
 	end
 	if legacyMinimap then
 		for key, value in pairs(legacyMinimap) do
-			ns.db.global.minimap[key] = value
+			global.minimap[key] = value
 		end
 	end
 
-	-- Clear the legacy keys now that everything lives in the profile.
+	-- Clear the pre-AceDB keys now that their values live in global.
 	MagicEraserDB.showWelcome = nil
 	MagicEraserDB.minimap = nil
 	MagicEraserDB.autoVendEnabled = nil
 	MagicEraserCharDB = nil
 
+	--[[
+	    MIGRATION (remove after 2026-10-11): the first AceDB build kept every
+	    setting on one shared "Default" profile. They are account-wide now, so
+	    move any a user actually changed up to global. These keys are no longer in
+	    the profile defaults, so a non-nil raw read means the user set it; clear it
+	    after. Idempotent across toons -- the first toon moves the shared value,
+	    later toons find it already gone.
+	]]
+	local rehomeKeys = {
+		"showWelcome",
+		"tooltipWarningEnabled",
+		"autoVendEnabled",
+		"autoVendMessagesEnabled",
+		"autoVendSummaryEnabled",
+		"bagsFullNudgeEnabled",
+		"bagsFullThreshold",
+		"safetyEnabled",
+		"safetyQuest",
+		"safetyConsumable",
+		"safetyWhite",
+		"safetyGray",
+	}
+	for _, key in ipairs(rehomeKeys) do
+		if profile[key] ~= nil then
+			global[key] = profile[key]
+			profile[key] = nil
+		end
+	end
+
+	if type(profile.ignoreLists) ~= "table" then
+		profile.ignoreLists = {}
+	end
+
+	--[[
+	    ONE-TIME RESET (remove after 2026-10-11): the first AceDB builds put every
+	    toon on one shared "Default" profile, merging all their ignore lists into a
+	    single flat profile.ignoreList. That pollution can't be unmerged, so the
+	    mere presence of that flat list marks an affected profile -- zero every
+	    per-character bucket in it (including any that an earlier build already
+	    seeded from the shared pool) and delete the flat list. Self-disabling once
+	    the flat list is gone, and scoped to the one profile that carried it. A
+	    pre-AceDB install never had a flat list, so it skips this entirely.
+	]]
+	if type(profile.ignoreList) == "table" then
+		wipe(profile.ignoreLists)
+		profile.ignoreList = nil
+	end
+
+	--[[
+	    MIGRATION (remove after 2026-10-11): seed this toon's bucket once, from its
+	    OWN pre-AceDB per-character list (MagicEraserCharDB) only -- one character's
+	    data, never the shared pool. A toon with no legacy list starts empty.
+	]]
+	if profile.ignoreLists[charKey] == nil then
+		local seeded = {}
+		if legacyIgnoreList then
+			for itemId in pairs(legacyIgnoreList) do
+				seeded[itemId] = true
+			end
+		end
+		profile.ignoreLists[charKey] = seeded
+	end
+
+	--[[
+	    MIGRATION (remove after 2026-10-11): the Verbose/Summary rollout forces
+	    Auto-Vend messages on once for everyone -- including users who had turned
+	    them off under the old per-item behavior. The marker has no default entry,
+	    so AceDB never strips it and the reset cannot re-fire. Messages are
+	    account-wide now, so both the marker and the target live in global.
+	]]
+	if not global.autoVendSummaryMigrated then
+		global.autoVendSummaryMigrated = true
+		global.autoVendMessagesEnabled = true
+	end
+
+	--[[
+	    CLEANUP (remove after 2026-10-11): the removed Delete Macro feature left an
+	    account-wide "- Eraser" macro on anyone who had enabled it. Delete that
+	    stray once so no broken macro lingers. Guarded on combat (DeleteMacro is
+	    protected) and marked done only after a real pass, so login-in-combat
+	    retries next time; the marker keeps it to a single pass so it can never
+	    clobber a same-named macro a user makes later.
+	]]
+	if not global.deleteMacroCleanupDone and not InCombatLockdown() then
+		if GetMacroIndexByName("- Eraser") > 0 then
+			DeleteMacro("- Eraser")
+		end
+		global.deleteMacroCleanupDone = true
+	end
+
 	ns:RegisterOptionsPanels()
+
+	--[[
+	    Reset Profile (AceDBOptions) resets only the profile scope, which now holds
+	    just the per-character ignore lists. Every other setting lives in global,
+	    which the profile reset never touches, so the button would leave all the
+	    real settings unchanged. Hook OnProfileReset to also restore the global
+	    settings to their defaults, so "Reset Profile" behaves like a full reset.
+	]]
+	ns.db.RegisterCallback(ns, "OnProfileReset", "OnDatabaseReset")
+
+	-- The erase candidate comes from the active profile's ignore lists, so a profile switch must re-scan immediately.
+	ns.db.RegisterCallback(ns, "OnProfileChanged", "OnProfileSwitched")
+	ns.db.RegisterCallback(ns, "OnProfileCopied", "OnProfileSwitched")
 
 	local LibDBIcon = LibStub("LibDBIcon-1.0")
 	if LibDBIcon and ns.LDBObject then
 		LibDBIcon:Register(ADDON_NAME, ns.LDBObject, ns.db.global.minimap)
 	end
 
-	if ns.db.profile.showWelcome then
+	if ns.db.global.showWelcome then
 		ns:PrintMessage(L["CHAT_LOADED"]:format(ns.Version))
 	end
 
+	--[[
+	    Seed the bag-space warning baseline with the free count we log in with, so
+	    the login-time BAG_UPDATE_DELAYED burst is treated as "already known" and
+	    does not fire a warning on load -- only a slot lost while playing does.
+	]]
+	lastNudgeFree = CountFreeSlots()
+
+	ns:RefreshDisplay()
+
+	--[[
+	    Install the tooltip hooks after every other add-on has set up its own, not
+	    at file load. Two reasons: (1) another add-on may install
+	    TooltipDataProcessor on a client that lacks it natively (so it must exist
+	    by the time we check), and (2) our secure hook must wrap the outermost
+	    layer other add-ons installed, or a heavier tooltip add-on's
+	    post-processing rebuilds the tooltip after us and clears our line.
+	    PLAYER_LOGIN fires once all add-ons are loaded; the extra C_Timer.After(0)
+	    lets every add-on's own PLAYER_LOGIN setup finish first.
+	]]
+	C_Timer.After(0, ns.SetupTooltipHooks)
+end
+
+--[[
+    Restore the account-wide (global) settings to their DATABASE_DEFAULTS values.
+    Fired from the AceDB OnProfileReset callback so the Reset Profile button
+    resets the whole add-on, not just the ignore lists. Scalar settings are set
+    back to their defaults; the minimap button is re-enabled (its default) but
+    left where it is, since its saved position is not a "setting" a reset should
+    move. Refreshes the display and repaints the options panel afterward.
+]]
+function ns:OnDatabaseReset()
+	local defaults = ns.DATABASE_DEFAULTS.global
+	local global = ns.db.global
+
+	for key, value in pairs(defaults) do
+		if type(value) ~= "table" then
+			global[key] = value
+		end
+	end
+
+	if type(global.minimap) == "table" then
+		global.minimap.hide = nil
+	end
+	local LibDBIcon = LibStub("LibDBIcon-1.0")
+	if LibDBIcon then
+		LibDBIcon:Show(ADDON_NAME)
+	end
+
+	ns:RefreshDisplay()
+
+	local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
+	AceConfigRegistry:NotifyChange(ns.OPTIONS_REGISTRY.General)
+end
+
+function ns:OnProfileSwitched()
 	ns:RefreshDisplay()
 end
 
@@ -373,8 +768,28 @@ function ns:OnBagUpdateDelayed()
 			ns:InvalidateCache()
 			ns:RefreshDisplay()
 			updatePending = false
+
+			--[[
+                Bag-space warning counts down (4, 3, 2, 1...) as the bags fill,
+                but only when no merchant or mailbox window is open -- see
+                CheckBagsFullNudge and OnMerchantClosed/OnMailClosed, which
+                defer the check to when the window closes.
+            ]]
+			if not IsBagWindowOpen() then
+				ns:CheckBagsFullNudge()
+			end
 		end)
 	end
+end
+
+--[[
+    Closing the mailbox is the counterpart to the merchant-close nudge in
+    Auto-Vend's OnMerchantClosed: bag-space warnings are held while the window is
+    open (see OnBagUpdateDelayed), so re-check once it closes to warn if looting
+    mail left the bags at or below the threshold.
+]]
+function ns:OnMailClosed()
+	ns:CheckBagsFullNudge()
 end
 
 function ns:OnQuestTurnedIn(questId)

--- a/Features/Diagnostics.lua
+++ b/Features/Diagnostics.lua
@@ -241,9 +241,9 @@ end
 --[[
     Existence and shape checks only: read-only, no side effects, no protected
     calls. Kept one-to-one with the APIs Magic Eraser calls or guards in Core.lua,
-    Auto-Vend.lua, Minimap-Button.lua, and Data/Data.lua. The C_AddOns /
-    GetAddOnMetadata pair is listed modern + legacy so the report shows what each
-    client provides -- the legacy global ships on Era but is gone on TBC.
+    Auto-Vend.lua, and Minimap-Button.lua. The C_AddOns / GetAddOnMetadata pair is
+    listed modern + legacy so the report shows what each client provides -- the
+    legacy global ships on Era but is gone on TBC.
 ]]
 ns.DIAGNOSTIC_API_CHECKS = {
 	-- { label, testFunction }
@@ -281,6 +281,12 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		"C_Container.UseContainerItem",
 		function()
 			return type(C_Container) == "table" and type(C_Container.UseContainerItem) == "function"
+		end,
+	},
+	{
+		"C_Container.GetContainerNumFreeSlots",
+		function()
+			return type(C_Container) == "table" and type(C_Container.GetContainerNumFreeSlots) == "function"
 		end,
 	},
 	{
@@ -332,33 +338,21 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"IsShiftKeyDown",
+		"StaticPopup_Show",
 		function()
-			return type(IsShiftKeyDown) == "function"
+			return type(StaticPopup_Show) == "function"
+		end,
+	},
+	{
+		"TooltipDataProcessor.AddTooltipPostCall",
+		function()
+			return type(TooltipDataProcessor) == "table" and type(TooltipDataProcessor.AddTooltipPostCall) == "function"
 		end,
 	},
 	{
 		"InCombatLockdown",
 		function()
 			return type(InCombatLockdown) == "function"
-		end,
-	},
-	{
-		"UnitLevel",
-		function()
-			return type(UnitLevel) == "function"
-		end,
-	},
-	{
-		"UnitClass",
-		function()
-			return type(UnitClass) == "function"
-		end,
-	},
-	{
-		"PlaySound",
-		function()
-			return type(PlaySound) == "function"
 		end,
 	},
 	{
@@ -383,18 +377,6 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		"SetCVar",
 		function()
 			return type(SetCVar) == "function"
-		end,
-	},
-	{
-		"GetBuildInfo",
-		function()
-			return type(GetBuildInfo) == "function"
-		end,
-	},
-	{
-		"GetLocale",
-		function()
-			return type(GetLocale) == "function"
 		end,
 	},
 }
@@ -425,9 +407,9 @@ function ns:BuildEraserContextReport()
 	local _, class = UnitClass("player")
 	lines[#lines + 1] = string.format("Player: %s level %d", tostring(class), UnitLevel("player") or 0)
 	lines[#lines + 1] =
-		string.format("Auto-Vend: %s", (ns.db and ns.db.profile.autoVendEnabled) and "enabled" or "disabled")
+		string.format("Auto-Vend: %s", (ns.db and ns.db.global.autoVendEnabled) and "enabled" or "disabled")
 
-	local ignoreCount = CountKeys(ns.db and ns.db.profile.ignoreList)
+	local ignoreCount = CountKeys(ns:GetIgnoreList())
 	lines[#lines + 1] = string.format("Ignore list: %d %s", ignoreCount, ignoreCount == 1 and "entry" or "entries")
 	lines[#lines + 1] = string.format(
 		"Databases: quest=%d, consumables=%d, equipment=%d",
@@ -533,19 +515,27 @@ end
 
 --[[
     Dumps the single AceDB-managed table (profiles, profileKeys, global) so a
-    player can paste their exact configuration. Each profile's ignoreList is
-    replaced with a length summary rather than printing every itemId (see DATA --
-    large lists are described, not reproduced).
+    player can paste their exact configuration. Each profile's per-character
+    ignoreLists is replaced with a per-character length summary rather than
+    printing every itemId (see DATA -- large lists are described, not reproduced).
 ]]
+local function SummarizeList(entry)
+	local count = CountKeys(entry)
+	return string.format("{ %d %s }", count, count == 1 and "entry" or "entries")
+end
+
 local function SummarizeForDump(value)
 	if type(value) ~= "table" then
 		return value
 	end
 	local copy = {}
 	for key, entry in pairs(value) do
-		if key == "ignoreList" and type(entry) == "table" then
-			local count = CountKeys(entry)
-			copy[key] = string.format("{ %d %s }", count, count == 1 and "entry" or "entries")
+		if key == "ignoreLists" and type(entry) == "table" then
+			local perChar = {}
+			for charKey, list in pairs(entry) do
+				perChar[charKey] = SummarizeList(list)
+			end
+			copy[key] = perChar
 		else
 			copy[key] = SummarizeForDump(entry)
 		end

--- a/Features/Item-Tooltips.lua
+++ b/Features/Item-Tooltips.lua
@@ -1,0 +1,133 @@
+local _, ns = ...
+local L = ns.L
+local GetColor = ns.GetColor
+
+--------------------------------------------------------------------------------
+-- Item Tooltip Warning
+--------------------------------------------------------------------------------
+
+--[[
+    Appends a single branded line to an item's tooltip: a warning when Magic
+    Eraser would erase the item, or a protection notice when the Ignore List is
+    shielding it. The verdict comes from the very rules the eraser's scan uses
+    (ns:IsIgnored, the class-reagent exclusions, and ns:GetItemDeleteReason), so
+    the line shows only when the item truly would be erased -- the consumable
+    level gate and quest-completion check included. Purely read-only.
+
+    Two hook paths, because the tooltip API differs across the flavors we target:
+    modern clients expose the data-driven TooltipDataProcessor; others lack it and
+    instead get a hooksecurefunc on GameTooltip:SetBagItem. Hooking the setter (not
+    the shared OnTooltipSetItem script) means our line is added AFTER other add-ons'
+    OnTooltipSetItem rebuilds, so a heavy tooltip add-on like TSM that clears and
+    re-fills the tooltip can't wipe our line. Only one path is ever active, so the
+    line is never doubled.
+
+    Layout mirrors the add-on's chat output -- ns.BrandPrefix ("Magic Eraser //")
+    plus a colored body -- under a one-line spacer, so it reads as a distinct
+    footer near the bottom of the tooltip. Green (ON) for protected, red (OFF)
+    for will-erase.
+]]
+--[[
+    True only when the tooltip is anchored to one of the player's carried bag
+    slots (bags 0..NUM_BAG_SLOTS) -- never a merchant, bank, or chat-link tooltip.
+    Used by the TooltipDataProcessor path, which fires for every item tooltip and
+    so needs this filter; the SetBagItem path is already bag-scoped by its own
+    args. Modern container item buttons expose GetBagID(); the default frames fall
+    back to their ContainerFrame name and the parent frame's bag id.
+]]
+local function IsCarriedBagSlot(tooltip)
+	local owner = tooltip:GetOwner()
+	if not owner then
+		return false
+	end
+
+	local getBagID = owner.GetBagID
+	if type(getBagID) == "function" then
+		local ok, bag = pcall(getBagID, owner)
+		if ok and type(bag) == "number" then
+			return bag >= 0 and bag <= NUM_BAG_SLOTS
+		end
+	end
+
+	local name = owner.GetName and owner:GetName()
+	if name and name:find("ContainerFrame", 1, true) then
+		local parent = owner.GetParent and owner:GetParent()
+		local bag = parent and parent.GetID and parent:GetID()
+		if type(bag) == "number" then
+			return bag >= 0 and bag <= NUM_BAG_SLOTS
+		end
+	end
+
+	return false
+end
+
+local function AddEraserWarning(tooltip, itemId)
+	if tooltip ~= GameTooltip or not (ns.db and ns.db.global.tooltipWarningEnabled) then
+		return
+	end
+	if not itemId then
+		return
+	end
+
+	-- Ignore List protection wins over any erase verdict.
+	if ns:IsIgnored(itemId) then
+		tooltip:AddLine(" ")
+		tooltip:AddLine(ns.BrandPrefix .. GetColor("TEXT") .. L["TOOLTIP_IGNORED"] .. "|r")
+		return true
+	end
+
+	-- Class reagents the scan skips are never erased; say nothing.
+	local _, playerClass = UnitClass("player")
+	local classReagentExclusions = (ns.ClassReagentExclusions and ns.ClassReagentExclusions[playerClass]) or {}
+	if classReagentExclusions[itemId] then
+		return
+	end
+
+	-- Cold item cache: let the API resolve and add nothing this pass.
+	local _, _, rarity, _, requiredLevel, _, _, _, _, _, sellPrice = GetItemInfo(itemId)
+	if rarity == nil then
+		return
+	end
+
+	if ns:GetItemDeleteReason(itemId, rarity, sellPrice, requiredLevel) then
+		tooltip:AddLine(" ")
+		tooltip:AddLine(ns.BrandPrefix .. GetColor("OFF") .. L["TOOLTIP_WILL_ERASE"] .. "|r")
+		return true
+	end
+end
+
+function ns.SetupTooltipHooks()
+	if TooltipDataProcessor and TooltipDataProcessor.AddTooltipPostCall then
+		-- Modern data-driven hook. Fires for any item tooltip, so gate to bag slots
+		-- (data.id is the itemID; see Enum.TooltipDataType.Item).
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(tooltip, data)
+			if IsCarriedBagSlot(tooltip) then
+				AddEraserWarning(tooltip, data and data.id)
+			end
+		end)
+	else
+		--[[
+		    Clients without TooltipDataProcessor: hook the bag-item setter.
+		    hooksecurefunc wraps whatever GameTooltip:SetBagItem currently is, so it
+		    runs after the wrapped function returns. Because this is registered late
+		    (see below), we wrap OTHER add-ons' hooks/wrappers -- TSM replaces the
+		    tooltip setters with prehook/orig/posthook wrappers on these clients --
+		    landing outermost, so our line is added last and survives their rebuilds.
+		    Bag-scoped: the bag arg is the container, and bank bags (5..11) are
+		    excluded by the range check, so no owner sniffing is needed.
+
+		    Running outermost means the tooltip has already been sized and shown, so
+		    AddLine alone would render our line outside the frame. Re-Show() when we
+		    added a line so the tooltip grows to include it.
+		]]
+		hooksecurefunc(GameTooltip, "SetBagItem", function(tooltip, bag, slot)
+			if type(bag) ~= "number" or bag < 0 or bag > NUM_BAG_SLOTS then
+				return
+			end
+			local info = C_Container and C_Container.GetContainerItemInfo(bag, slot)
+			if AddEraserWarning(tooltip, info and info.itemID) then
+				tooltip:Show()
+			end
+		end)
+	end
+end

--- a/Features/Minimap-Button.lua
+++ b/Features/Minimap-Button.lua
@@ -25,6 +25,23 @@ local function RefreshTooltip(anchor)
 
 	local item = ns:FindItemToDelete()
 
+	-- Clutter Report (always at the top). With clutter it summarizes the haul;
+	-- with clean bags it carries the congratulations message instead.
+	tooltip:AddLine(GetColor("TITLE") .. L["CLUTTER_REPORT"] .. "|r")
+	if item then
+		local reclaimSlots, reclaimItems, reclaimValue = ns:GetReclaimSummary()
+		local slotsText = GetColor("TEXT") .. format(L["CLUTTER_SLOTS"], ns:FormatCommaNumber(reclaimSlots)) .. "|r"
+		local itemsText = GetColor("MUTED") .. format(L["CLUTTER_ITEMS"], ns:FormatCommaNumber(reclaimItems)) .. "|r"
+		tooltip:AddDoubleLine(
+			slotsText .. " " .. itemsText,
+			GetColor("TEXT") .. format(L["CLUTTER_VALUE"], ns:FormatCurrency(reclaimValue)) .. "|r"
+		)
+	else
+		tooltip:AddLine(GetColor("ON") .. L["BAGS_CLEAN_SHORT"] .. "|r", 1, 1, 1, true)
+	end
+
+	tooltip:AddLine(" ")
+
 	if item then
 		-- Lowest Value Item
 		tooltip:AddLine(GetColor("TITLE") .. L["LOWEST_VALUE_ITEM"] .. "|r")
@@ -47,15 +64,13 @@ local function RefreshTooltip(anchor)
 			GetColor("INFO") .. L["ACTION_IGNORE"] .. "|r"
 		)
 	else
-		-- Clean Bags
-		tooltip:AddLine(GetColor("ON") .. L["BAGS_CLEAN_SHORT"] .. "|r", 1, 1, 1, true)
-		tooltip:AddLine(" ")
+		-- Replaces the Lowest Value Item section when bags are clean.
 		tooltip:AddLine(GetColor("BODY") .. L["BAGS_CLEAN_HINT"] .. "|r", 1, 1, 1, true)
 	end
 
 	-- Auto-Vend
 	tooltip:AddLine(" ")
-	local autoVendStatus = (ns.db and ns.db.profile.autoVendEnabled) and (GetColor("ON") .. L["ON"] .. "|r")
+	local autoVendStatus = (ns.db and ns.db.global.autoVendEnabled) and (GetColor("ON") .. L["ON"] .. "|r")
 		or (GetColor("OFF") .. L["OFF"] .. "|r")
 	tooltip:AddDoubleLine(L["AUTO_VEND"], autoVendStatus)
 	tooltip:AddLine(GetColor("BODY") .. L["AUTO_VEND_DESCRIPTION"] .. "|r", 1, 1, 1, true)
@@ -65,8 +80,9 @@ local function RefreshTooltip(anchor)
 		GetColor("INFO") .. L["ACTION_TOGGLE"] .. "|r"
 	)
 
-	-- Ignore List
-	local hasIgnoredItems = ns.db and ns.db.profile.ignoreList and next(ns.db.profile.ignoreList) ~= nil
+	-- Ignore List (per character)
+	local ignoreList = ns:GetIgnoreList()
+	local hasIgnoredItems = ignoreList and next(ignoreList) ~= nil
 
 	if hasIgnoredItems then
 		tooltip:AddLine(" ")
@@ -75,7 +91,7 @@ local function RefreshTooltip(anchor)
 		local sortedItems = {}
 		local loadingItems = {}
 
-		for itemId in pairs(ns.db.profile.ignoreList) do
+		for itemId in pairs(ignoreList) do
 			local name, _, quality, _, _, _, _, _, _, icon = GetItemInfo(itemId)
 			if name then
 				insert(sortedItems, { name = name, quality = quality, icon = icon })
@@ -163,7 +179,10 @@ if LibDataBroker then
 			end
 
 			if IsShiftKeyDown() and button == "RightButton" then
-				ns.db.profile.autoVendEnabled = not ns.db.profile.autoVendEnabled
+				if not ns.db then
+					return
+				end
+				ns.db.global.autoVendEnabled = not ns.db.global.autoVendEnabled
 				AceConfigRegistry:NotifyChange(ns.OPTIONS_REGISTRY.General)
 				RefreshTooltip(self)
 				return

--- a/Features/Utilities.lua
+++ b/Features/Utilities.lua
@@ -38,7 +38,7 @@ ns.BrandPrefix = string.format("%s%s|r %s//|r ", COLORS.INFO, ns.AddonTitle, COL
 local format, insert, floor = string.format, table.insert, math.floor
 
 function ns:FormatCommaNumber(number)
-	return tostring(number):reverse():gsub("(%d%d%d)", "%1,"):reverse():gsub("^,", "")
+	return (tostring(number):reverse():gsub("(%d%d%d)", "%1,"):reverse():gsub("^,", ""))
 end
 
 function ns:FormatCurrency(rawValue)

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Version %s. Einstellungen (einschließlich der Option, diese Nachricht zu deaktivieren) findest du unter Optionen > AddOns > Magic Eraser. Gefällt dir das Add-on? Erzähle einem Freund davon! (="
+L["CHAT_LOADED"] =
+	"Version %s. Einstellungen (einschließlich der Option, diese Nachricht zu deaktivieren) findest du unter Optionen > AddOns > Magic Eraser. Gefällt dir das Add-on? Erzähle einem Freund davon! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Gegenstände können im Kampf nicht gelöscht werden."
+L["CONFIRM_ERASE"] = "%s%s löschen?"
+L["BAGS_FULL"] = "Deine Taschen sind voll!"
+L["BAGS_FULL_NUDGE"] = "Deine Taschen sind fast voll. Du hast noch %d freie Plätze."
+L["BAGS_FULL_NUDGE_ONE"] = "Deine Taschen sind fast voll. Du hast noch 1 freien Platz."
 L["CURSOR_TOO_FAST"] = "Langsamer! Du klickst schneller als das Spiel Gegenstände löschen kann."
 L["ERASED_ITEM"] = "%s%s%s gelöscht."
 L["ERASED_VALUE_SUFFIX"] = ", Wert %s"
 L["ERASED_QUEST_SUFFIX"] = ", dieser Gegenstand gehörte zu einer abgeschlossenen Quest"
 L["QUEST_ITEM_READY"] = "%s kann jetzt sicher gelöscht werden!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser wird dies löschen."
+L["TOOLTIP_IGNORED"] = "Durch deine Ignorierliste geschützt."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s verkauft, Wert %s."
+L["SOLD_SUMMARY"] = "%s Gegenstände verkauft, Wert %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-Verkauf wird ausgeführt, sobald der Kampf endet."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-Verkauf wird ausgeführt, sobald der Kamp
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Gegenstand mit geringstem Wert"
+L["CLUTTER_REPORT"] = "Ramsch-Bericht"
+L["CLUTTER_SLOTS"] = "%s Plätze"
+L["CLUTTER_ITEMS"] = "(%s Gegenstände)"
+L["CLUTTER_VALUE"] = "Wert %s"
 L["NO_VALUE"] = "Kein Wert"
 L["LEFT_CLICK"] = "Linksklick"
 L["RIGHT_CLICK"] = "Rechtsklick"
@@ -62,15 +76,41 @@ L["OFF"] = "Deaktiviert"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Räume deine Taschen im Handumdrehen auf. Abgeschlossene Questgegenstände, niedrigstufige Verbrauchsgüter, weiße Gegenstände in Händlerqualität und grauer Müll werden mit jedem Klick auf die Minikarten-Schaltfläche gelöscht. Wenn du einen Händler besuchst, wird alles Verkäufliche automatisch verkauft."
+L["OPTIONS_DESCRIPTION"] =
+	"Räume deine Taschen im Handumdrehen auf. Abgeschlossene Questgegenstände, niedrigstufige Verbrauchsgüter, weiße Gegenstände in Händlerqualität und grauer Müll werden mit jedem Klick auf die Minikarten-Schaltfläche gelöscht. Wenn du einen Händler besuchst, wird alles Verkäufliche automatisch verkauft."
 L["OPTIONS_WELCOME"] = "Willkommensnachricht aktivieren"
 L["OPTIONS_MINIMAP"] = "Minikarten-Schaltfläche aktivieren"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Verkauft automatisch Gegenstände, die von Magic Eraser als Ramsch markiert sind, wenn du ein Händlerfenster öffnest."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Befehle"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Öffnet das Einstellungsmenü von Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Gegenstands-Tooltips"
+L["OPTIONS_TOOLTIP_WARNING"] = "Tooltips für Gegenstände in Taschen aktivieren"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Verkauft automatisch Gegenstände, die von Magic Eraser als Ramsch markiert sind, wenn du ein Händlerfenster öffnest."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Auto-Verkauf aktivieren"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Auto-Verkauf-Nachrichten aktivieren"
-L["OPTIONS_COMMANDS_HEADER"] = "/Befehle"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Öffnet das Einstellungsmenü von Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Einzelposten"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Zusammenfassung"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Taschenplatz-Warnungen"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Taschenplatz-Warnungen aktivieren"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Schwellenwert für freie Plätze"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Lösch-Bestätigungen"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Vor dem Löschen der unten markierten Gegenstandstypen nachfragen."
+L["OPTIONS_ENABLE_SAFETY"] = "Lösch-Bestätigungen aktivieren"
+L["OPTIONS_SAFETY_QUEST"] = "Für Gegenstände abgeschlossener Quests"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Für niedrigstufige Verbrauchsgüter"
+L["OPTIONS_SAFETY_WHITE"] = "Für weiße Gegenstände in Händlerqualität"
+L["OPTIONS_SAFETY_GRAY"] = "Für graue Gegenstände in Händlerqualität"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback & Unterstützung"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -19,14 +19,23 @@ L["CHAT_LOADED"] =
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Cannot erase items while in combat."
+L["CONFIRM_ERASE"] = "Erase %s%s?"
+L["BAGS_FULL"] = "Your bags are full!"
+L["BAGS_FULL_NUDGE"] = "Your bags are nearly full. You have %d slots remaining."
+L["BAGS_FULL_NUDGE_ONE"] = "Your bags are nearly full. You have 1 slot remaining."
 L["CURSOR_TOO_FAST"] = "Slow down! You are clicking faster than the game can erase items."
 L["ERASED_ITEM"] = "Erased %s%s%s."
 L["ERASED_VALUE_SUFFIX"] = ", worth %s"
 L["ERASED_QUEST_SUFFIX"] = ", this item was associated with a quest you have completed"
 L["QUEST_ITEM_READY"] = "%s can now be safely erased!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser will erase this."
+L["TOOLTIP_IGNORED"] = "Protected by your Ignore List."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "Sold %s%s, worth %s."
+L["SOLD_SUMMARY"] = "Sold %s items, worth %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-Vend will sell once combat ends."
 
 --------------------------------------------------------------------------------
@@ -34,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-Vend will sell once combat ends."
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Lowest Value Item"
+L["CLUTTER_REPORT"] = "Clutter Report"
+L["CLUTTER_SLOTS"] = "%s Slots"
+L["CLUTTER_ITEMS"] = "(%s Items)"
+L["CLUTTER_VALUE"] = "Value %s"
 L["NO_VALUE"] = "No Value"
 L["LEFT_CLICK"] = "Left-Click"
 L["RIGHT_CLICK"] = "Right-Click"
@@ -67,13 +80,37 @@ L["OPTIONS_DESCRIPTION"] =
 	"Clean up your bags instantly. Completed quest items, low-level consumables, vendor-quality whites, and gray trash are erased with each click of the mini-map button. When you visit a merchant, anything that can be is sold automatically."
 L["OPTIONS_WELCOME"] = "Enable Welcome Message"
 L["OPTIONS_MINIMAP"] = "Enable Mini-map Button"
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Opens the Magic Eraser options interface."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Item Tooltips"
+L["OPTIONS_TOOLTIP_WARNING"] = "Enable Tooltips for In-Bag Items"
+
+-- Auto-Vend
 L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
 	"Automatically sell items flagged as junk by Magic Eraser when you open a merchant window."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Enable Auto-Vend"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Enable Auto-Vend Messages"
-L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Opens the Magic Eraser options interface."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Line Item"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Summary"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Bag-Space Warnings"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Enable Bag-Space Warnings"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Free-Slot Threshold"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Eraser Confirmations"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Ask before erasing the item types you check below."
+L["OPTIONS_ENABLE_SAFETY"] = "Enable Eraser Confirmations"
+L["OPTIONS_SAFETY_QUEST"] = "For Completed Quest Items"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "For Low-level Consumable Items"
+L["OPTIONS_SAFETY_WHITE"] = "For White Vendor-quality Items"
+L["OPTIONS_SAFETY_GRAY"] = "For Gray Vendor-quality Items"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback & Support"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Versión %s. Los ajustes (incluyendo la opción para desactivar este mensaje) se pueden encontrar en Opciones > AddOns > Magic Eraser. ¿Disfrutando del add-on? ¡Díselo a un amigo! (="
+L["CHAT_LOADED"] =
+	"Versión %s. Los ajustes (incluyendo la opción para desactivar este mensaje) se pueden encontrar en Opciones > AddOns > Magic Eraser. ¿Disfrutando del add-on? ¡Díselo a un amigo! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "No se pueden eliminar objetos durante el combate."
+L["CONFIRM_ERASE"] = "¿Eliminar %s%s?"
+L["BAGS_FULL"] = "¡Tus bolsas están llenas!"
+L["BAGS_FULL_NUDGE"] = "Tus bolsas están casi llenas. Te quedan %d espacios."
+L["BAGS_FULL_NUDGE_ONE"] = "Tus bolsas están casi llenas. Te queda 1 espacio."
 L["CURSOR_TOO_FAST"] = "¡Más despacio! Estás haciendo clic más rápido de lo que el juego puede eliminar objetos."
 L["ERASED_ITEM"] = "%s%s%s eliminado."
 L["ERASED_VALUE_SUFFIX"] = ", valor %s"
 L["ERASED_QUEST_SUFFIX"] = ", este objeto estaba asociado a una misión completada"
 L["QUEST_ITEM_READY"] = "¡%s ahora se puede eliminar de forma segura!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser eliminará esto."
+L["TOOLTIP_IGNORED"] = "Protegido por tu lista de ignorados."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s vendido, valor %s."
+L["SOLD_SUMMARY"] = "%s objetos vendidos, valor %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-venta venderá los objetos al terminar el combate."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-venta venderá los objetos al terminar el
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Objeto de menor valor"
+L["CLUTTER_REPORT"] = "Informe de basura"
+L["CLUTTER_SLOTS"] = "%s espacios"
+L["CLUTTER_ITEMS"] = "(%s objetos)"
+L["CLUTTER_VALUE"] = "Valor %s"
 L["NO_VALUE"] = "Sin valor"
 L["LEFT_CLICK"] = "Clic izquierdo"
 L["RIGHT_CLICK"] = "Clic derecho"
@@ -62,15 +76,41 @@ L["OFF"] = "Desactivado"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Limpia tus bolsas al instante. Los objetos de misiones completadas, consumibles de bajo nivel, objetos blancos de calidad de vendedor y basura gris se eliminan con cada clic en el botón del minimapa. Cuando visitas a un comerciante, todo lo que se puede vender se vende automáticamente."
+L["OPTIONS_DESCRIPTION"] =
+	"Limpia tus bolsas al instante. Los objetos de misiones completadas, consumibles de bajo nivel, objetos blancos de calidad de vendedor y basura gris se eliminan con cada clic en el botón del minimapa. Cuando visitas a un comerciante, todo lo que se puede vender se vende automáticamente."
 L["OPTIONS_WELCOME"] = "Habilitar mensaje de bienvenida"
 L["OPTIONS_MINIMAP"] = "Habilitar botón del minimapa"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Vende automáticamente los objetos marcados como basura por Magic Eraser al abrir una ventana de comerciante."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Abre la interfaz de opciones de Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Descripciones de objetos"
+L["OPTIONS_TOOLTIP_WARNING"] = "Habilitar descripciones para objetos en las bolsas"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Vende automáticamente los objetos marcados como basura por Magic Eraser al abrir una ventana de comerciante."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Habilitar Auto-venta"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Habilitar mensajes de Auto-venta"
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Abre la interfaz de opciones de Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Por objeto"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Resumen"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Avisos de espacio en bolsas"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Habilitar avisos de espacio en bolsas"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Umbral de espacios libres"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Confirmaciones de eliminación"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Preguntar antes de eliminar los tipos de objeto que marques abajo."
+L["OPTIONS_ENABLE_SAFETY"] = "Habilitar confirmaciones de eliminación"
+L["OPTIONS_SAFETY_QUEST"] = "Para objetos de misiones completadas"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Para consumibles de bajo nivel"
+L["OPTIONS_SAFETY_WHITE"] = "Para objetos blancos de calidad de vendedor"
+L["OPTIONS_SAFETY_GRAY"] = "Para objetos grises de calidad de vendedor"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Comentarios y soporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/esMX.lua
+++ b/Locales/esMX.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Versión %s. Los ajustes (incluyendo la opción para desactivar este mensaje) se pueden encontrar en Opciones > AddOns > Magic Eraser. ¿Disfrutando del add-on? ¡Díselo a un amigo! (="
+L["CHAT_LOADED"] =
+	"Versión %s. Los ajustes (incluyendo la opción para desactivar este mensaje) se pueden encontrar en Opciones > AddOns > Magic Eraser. ¿Disfrutando del add-on? ¡Díselo a un amigo! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "No se pueden eliminar objetos durante el combate."
+L["CONFIRM_ERASE"] = "¿Eliminar %s%s?"
+L["BAGS_FULL"] = "¡Tus bolsas están llenas!"
+L["BAGS_FULL_NUDGE"] = "Tus bolsas están casi llenas. Te quedan %d espacios."
+L["BAGS_FULL_NUDGE_ONE"] = "Tus bolsas están casi llenas. Te queda 1 espacio."
 L["CURSOR_TOO_FAST"] = "¡Más despacio! Estás haciendo clic más rápido de lo que el juego puede eliminar objetos."
 L["ERASED_ITEM"] = "%s%s%s eliminado."
 L["ERASED_VALUE_SUFFIX"] = ", valor %s"
 L["ERASED_QUEST_SUFFIX"] = ", este objeto estaba asociado a una misión completada"
 L["QUEST_ITEM_READY"] = "¡%s ahora se puede eliminar de forma segura!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser eliminará esto."
+L["TOOLTIP_IGNORED"] = "Protegido por tu lista de ignorados."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s vendido, valor %s."
+L["SOLD_SUMMARY"] = "%s objetos vendidos, valor %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-venta venderá los objetos al terminar el combate."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "Auto-venta venderá los objetos al terminar el
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Objeto de menor valor"
+L["CLUTTER_REPORT"] = "Informe de basura"
+L["CLUTTER_SLOTS"] = "%s espacios"
+L["CLUTTER_ITEMS"] = "(%s objetos)"
+L["CLUTTER_VALUE"] = "Valor %s"
 L["NO_VALUE"] = "Sin valor"
 L["LEFT_CLICK"] = "Clic izquierdo"
 L["RIGHT_CLICK"] = "Clic derecho"
@@ -62,15 +76,41 @@ L["OFF"] = "Desactivado"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Limpia tus bolsas al instante. Los objetos de misiones completadas, consumibles de bajo nivel, objetos blancos de calidad de vendedor y basura gris se eliminan con cada clic en el botón del minimapa. Cuando visitas a un comerciante, todo lo que se puede vender se vende automáticamente."
+L["OPTIONS_DESCRIPTION"] =
+	"Limpia tus bolsas al instante. Los objetos de misiones completadas, consumibles de bajo nivel, objetos blancos de calidad de vendedor y basura gris se eliminan con cada clic en el botón del minimapa. Cuando visitas a un comerciante, todo lo que se puede vender se vende automáticamente."
 L["OPTIONS_WELCOME"] = "Habilitar mensaje de bienvenida"
 L["OPTIONS_MINIMAP"] = "Habilitar botón del minimapa"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Vende automáticamente los objetos marcados como basura por Magic Eraser al abrir una ventana de comerciante."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Abre la interfaz de opciones de Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Descripciones de objetos"
+L["OPTIONS_TOOLTIP_WARNING"] = "Habilitar descripciones para objetos en las bolsas"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Vende automáticamente los objetos marcados como basura por Magic Eraser al abrir una ventana de comerciante."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Habilitar Auto-venta"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Habilitar mensajes de Auto-venta"
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Abre la interfaz de opciones de Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Por objeto"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Resumen"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Avisos de espacio en bolsas"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Habilitar avisos de espacio en bolsas"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Umbral de espacios libres"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Confirmaciones de eliminación"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Preguntar antes de eliminar los tipos de objeto que marques abajo."
+L["OPTIONS_ENABLE_SAFETY"] = "Habilitar confirmaciones de eliminación"
+L["OPTIONS_SAFETY_QUEST"] = "Para objetos de misiones completadas"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Para consumibles de bajo nivel"
+L["OPTIONS_SAFETY_WHITE"] = "Para objetos blancos de calidad de vendedor"
+L["OPTIONS_SAFETY_GRAY"] = "Para objetos grises de calidad de vendedor"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Comentarios y soporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Version %s. Les paramètres (y compris l'option pour désactiver ce message) se trouvent dans Options > Extensions > Magic Eraser. Vous appréciez l'extension ? Parlez-en à un ami ! (="
+L["CHAT_LOADED"] =
+	"Version %s. Les paramètres (y compris l'option pour désactiver ce message) se trouvent dans Options > Extensions > Magic Eraser. Vous appréciez l'extension ? Parlez-en à un ami ! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Impossible de supprimer des objets en combat."
+L["CONFIRM_ERASE"] = "Supprimer %s%s ?"
+L["BAGS_FULL"] = "Vos sacs sont pleins !"
+L["BAGS_FULL_NUDGE"] = "Vos sacs sont presque pleins. Il vous reste %d emplacements."
+L["BAGS_FULL_NUDGE_ONE"] = "Vos sacs sont presque pleins. Il vous reste 1 emplacement."
 L["CURSOR_TOO_FAST"] = "Doucement ! Vous cliquez plus vite que le jeu ne peut supprimer les objets."
 L["ERASED_ITEM"] = "%s%s%s supprimé."
 L["ERASED_VALUE_SUFFIX"] = ", valeur %s"
 L["ERASED_QUEST_SUFFIX"] = ", cet objet était associé à une quête terminée"
 L["QUEST_ITEM_READY"] = "%s peut maintenant être supprimé en toute sécurité !"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser va supprimer ceci."
+L["TOOLTIP_IGNORED"] = "Protégé par votre liste d'ignorés."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s vendu, valeur %s."
+L["SOLD_SUMMARY"] = "%s objets vendus, valeur %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "La vente automatique s'effectuera à la fin du combat."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "La vente automatique s'effectuera à la fin du
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Objet de plus faible valeur"
+L["CLUTTER_REPORT"] = "Rapport de rebut"
+L["CLUTTER_SLOTS"] = "%s emplacements"
+L["CLUTTER_ITEMS"] = "(%s objets)"
+L["CLUTTER_VALUE"] = "Valeur %s"
 L["NO_VALUE"] = "Aucune valeur"
 L["LEFT_CLICK"] = "Clic gauche"
 L["RIGHT_CLICK"] = "Clic droit"
@@ -62,15 +76,41 @@ L["OFF"] = "Désactivé"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Nettoyez vos sacs en un instant. Les objets de quête terminés, les consommables de bas niveau, les objets blancs de qualité vendeur et la camelote grise sont supprimés à chaque clic sur le bouton de la minicarte. Lorsque vous visitez un marchand, tout ce qui peut l'être est vendu automatiquement."
+L["OPTIONS_DESCRIPTION"] =
+	"Nettoyez vos sacs en un instant. Les objets de quête terminés, les consommables de bas niveau, les objets blancs de qualité vendeur et la camelote grise sont supprimés à chaque clic sur le bouton de la minicarte. Lorsque vous visitez un marchand, tout ce qui peut l'être est vendu automatiquement."
 L["OPTIONS_WELCOME"] = "Activer le message de bienvenue"
 L["OPTIONS_MINIMAP"] = "Activer le bouton de la minicarte"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Vend automatiquement les objets signalés comme rebut par Magic Eraser à l'ouverture d'une fenêtre de marchand."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commandes"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Ouvre l'interface des options de Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Infobulles d'objets"
+L["OPTIONS_TOOLTIP_WARNING"] = "Activer les infobulles pour les objets dans les sacs"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Vend automatiquement les objets signalés comme rebut par Magic Eraser à l'ouverture d'une fenêtre de marchand."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Activer la Vente auto"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Activer les messages de Vente auto"
-L["OPTIONS_COMMANDS_HEADER"] = "/Commandes"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Ouvre l'interface des options de Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Par objet"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Résumé"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Alertes d'espace de sac"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Activer les alertes d'espace de sac"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Seuil d'emplacements libres"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Confirmations de suppression"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Demander avant de supprimer les types d'objets cochés ci-dessous."
+L["OPTIONS_ENABLE_SAFETY"] = "Activer les confirmations de suppression"
+L["OPTIONS_SAFETY_QUEST"] = "Pour les objets de quête terminés"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Pour les consommables de bas niveau"
+L["OPTIONS_SAFETY_WHITE"] = "Pour les objets blancs de qualité vendeur"
+L["OPTIONS_SAFETY_GRAY"] = "Pour les objets gris de qualité vendeur"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Commentaires et assistance"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Versione %s. Le impostazioni (inclusa l'opzione per disabilitare questo messaggio) si trovano in Opzioni > AddOn > Magic Eraser. Ti piace l'add-on? Dillo a un amico! (="
+L["CHAT_LOADED"] =
+	"Versione %s. Le impostazioni (inclusa l'opzione per disabilitare questo messaggio) si trovano in Opzioni > AddOn > Magic Eraser. Ti piace l'add-on? Dillo a un amico! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Non puoi eliminare oggetti durante il combattimento."
+L["CONFIRM_ERASE"] = "Eliminare %s%s?"
+L["BAGS_FULL"] = "Le tue borse sono piene!"
+L["BAGS_FULL_NUDGE"] = "Le tue borse sono quasi piene. Ti restano %d slot."
+L["BAGS_FULL_NUDGE_ONE"] = "Le tue borse sono quasi piene. Ti resta 1 slot."
 L["CURSOR_TOO_FAST"] = "Piano! Stai cliccando più velocemente di quanto il gioco possa eliminare gli oggetti."
 L["ERASED_ITEM"] = "%s%s%s eliminato."
 L["ERASED_VALUE_SUFFIX"] = ", valore %s"
 L["ERASED_QUEST_SUFFIX"] = ", questo oggetto era associato a una missione completata"
 L["QUEST_ITEM_READY"] = "%s ora può essere eliminato in sicurezza!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser eliminerà questo oggetto."
+L["TOOLTIP_IGNORED"] = "Protetto dalla tua lista ignorati."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s venduto, valore %s."
+L["SOLD_SUMMARY"] = "%s oggetti venduti, valore %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "La vendita automatica avverrà al termine del combattimento."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "La vendita automatica avverrà al termine del 
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Oggetto di minor valore"
+L["CLUTTER_REPORT"] = "Rapporto spazzatura"
+L["CLUTTER_SLOTS"] = "%s slot"
+L["CLUTTER_ITEMS"] = "(%s oggetti)"
+L["CLUTTER_VALUE"] = "Valore %s"
 L["NO_VALUE"] = "Nessun valore"
 L["LEFT_CLICK"] = "Clic sinistro"
 L["RIGHT_CLICK"] = "Clic destro"
@@ -62,15 +76,41 @@ L["OFF"] = "Disattivato"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Riordina le tue borse all'istante. Oggetti di missioni completate, consumabili di basso livello, oggetti bianchi di qualità dal mercante e spazzatura grigia vengono eliminati a ogni clic sul pulsante della minimappa. Quando visiti un mercante, tutto ciò che è vendibile viene venduto automaticamente."
+L["OPTIONS_DESCRIPTION"] =
+	"Riordina le tue borse all'istante. Oggetti di missioni completate, consumabili di basso livello, oggetti bianchi di qualità dal mercante e spazzatura grigia vengono eliminati a ogni clic sul pulsante della minimappa. Quando visiti un mercante, tutto ciò che è vendibile viene venduto automaticamente."
 L["OPTIONS_WELCOME"] = "Abilita messaggio di benvenuto"
 L["OPTIONS_MINIMAP"] = "Abilita pulsante della minimappa"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Vende automaticamente gli oggetti segnalati come spazzatura da Magic Eraser quando apri la finestra di un mercante."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Comandi"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Apre l'interfaccia delle opzioni di Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Descrizioni oggetti"
+L["OPTIONS_TOOLTIP_WARNING"] = "Abilita descrizioni per gli oggetti nelle borse"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Vende automaticamente gli oggetti segnalati come spazzatura da Magic Eraser quando apri la finestra di un mercante."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Abilita Vendita automatica"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Abilita messaggi Vendita automatica"
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandi"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Apre l'interfaccia delle opzioni di Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Per oggetto"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Riepilogo"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Avvisi di spazio nelle borse"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Abilita avvisi di spazio nelle borse"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Soglia di slot liberi"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Conferme di eliminazione"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Chiedi conferma prima di eliminare i tipi di oggetto selezionati sotto."
+L["OPTIONS_ENABLE_SAFETY"] = "Abilita conferme di eliminazione"
+L["OPTIONS_SAFETY_QUEST"] = "Per gli oggetti di missioni completate"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Per i consumabili di basso livello"
+L["OPTIONS_SAFETY_WHITE"] = "Per gli oggetti bianchi di qualità dal mercante"
+L["OPTIONS_SAFETY_GRAY"] = "Per gli oggetti grigi di qualità dal mercante"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback e supporto"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "버전 %s. 설정(이 메시지를 비활성화하는 옵션 포함)은 옵션 > 애드온 > Magic Eraser에서 찾을 수 있습니다. 애드온이 마음에 드시나요? 친구에게 알려주세요! (="
+L["CHAT_LOADED"] =
+	"버전 %s. 설정(이 메시지를 비활성화하는 옵션 포함)은 옵션 > 애드온 > Magic Eraser에서 찾을 수 있습니다. 애드온이 마음에 드시나요? 친구에게 알려주세요! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "전투 중에는 아이템을 삭제할 수 없습니다."
+L["CONFIRM_ERASE"] = "%s%s 삭제하시겠습니까?"
+L["BAGS_FULL"] = "가방이 가득 찼습니다!"
+L["BAGS_FULL_NUDGE"] = "가방이 거의 찼습니다. %d칸 남았습니다."
+L["BAGS_FULL_NUDGE_ONE"] = "가방이 거의 찼습니다. 1칸 남았습니다."
 L["CURSOR_TOO_FAST"] = "천천히! 게임이 아이템을 삭제하는 것보다 빠르게 클릭하고 있습니다."
 L["ERASED_ITEM"] = "%s%s%s 삭제됨."
 L["ERASED_VALUE_SUFFIX"] = ", 가치 %s"
 L["ERASED_QUEST_SUFFIX"] = ", 이 아이템은 완료된 퀘스트와 관련되어 있었습니다"
 L["QUEST_ITEM_READY"] = "%s 이제 안전하게 삭제할 수 있습니다!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser가 이 아이템을 삭제합니다."
+L["TOOLTIP_IGNORED"] = "무시 목록으로 보호됨."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s 판매됨, 가치 %s."
+L["SOLD_SUMMARY"] = "%s개 아이템 판매됨, 가치 %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "전투가 끝나면 자동 판매가 진행됩니다."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "전투가 끝나면 자동 판매가 진행됩
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "최저가 아이템"
+L["CLUTTER_REPORT"] = "잡동사니 보고서"
+L["CLUTTER_SLOTS"] = "%s칸"
+L["CLUTTER_ITEMS"] = "(%s개)"
+L["CLUTTER_VALUE"] = "가치 %s"
 L["NO_VALUE"] = "가치 없음"
 L["LEFT_CLICK"] = "좌클릭"
 L["RIGHT_CLICK"] = "우클릭"
@@ -62,15 +76,41 @@ L["OFF"] = "비활성화"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "가방을 즉시 정리하세요. 완료된 퀘스트 아이템, 저레벨 소모품, 상인 품질의 흰색 아이템, 회색 잡동사니가 미니맵 버튼을 클릭할 때마다 삭제됩니다. 상인을 방문하면 판매 가능한 것은 모두 자동으로 판매됩니다."
+L["OPTIONS_DESCRIPTION"] =
+	"가방을 즉시 정리하세요. 완료된 퀘스트 아이템, 저레벨 소모품, 상인 품질의 흰색 아이템, 회색 잡동사니가 미니맵 버튼을 클릭할 때마다 삭제됩니다. 상인을 방문하면 판매 가능한 것은 모두 자동으로 판매됩니다."
 L["OPTIONS_WELCOME"] = "환영 메시지 활성화"
 L["OPTIONS_MINIMAP"] = "미니맵 버튼 활성화"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "상인 창을 열 때 Magic Eraser가 잡동사니로 표시한 아이템을 자동으로 판매합니다."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/명령어"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Magic Eraser 설정 인터페이스를 엽니다."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "아이템 툴팁"
+L["OPTIONS_TOOLTIP_WARNING"] = "가방 속 아이템 툴팁 활성화"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"상인 창을 열 때 Magic Eraser가 잡동사니로 표시한 아이템을 자동으로 판매합니다."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "자동 판매 활성화"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "자동 판매 메시지 활성화"
-L["OPTIONS_COMMANDS_HEADER"] = "/명령어"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Magic Eraser 설정 인터페이스를 엽니다."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "항목별"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "요약"
+L["OPTIONS_BAGS_FULL_HEADER"] = "가방 공간 경고"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "가방 공간 경고 활성화"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "빈 칸 기준값"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "삭제 확인"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "아래에서 선택한 아이템 유형을 삭제하기 전에 확인합니다."
+L["OPTIONS_ENABLE_SAFETY"] = "삭제 확인 활성화"
+L["OPTIONS_SAFETY_QUEST"] = "완료된 퀘스트 아이템"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "저레벨 소모품"
+L["OPTIONS_SAFETY_WHITE"] = "상인 품질의 흰색 아이템"
+L["OPTIONS_SAFETY_GRAY"] = "상인 품질의 회색 아이템"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "피드백 및 지원"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Versão %s. As configurações (incluindo a opção de desativar esta mensagem) podem ser encontradas em Opções > AddOns > Magic Eraser. Gostando do add-on? Conte a um amigo! (="
+L["CHAT_LOADED"] =
+	"Versão %s. As configurações (incluindo a opção de desativar esta mensagem) podem ser encontradas em Opções > AddOns > Magic Eraser. Gostando do add-on? Conte a um amigo! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Não é possível excluir itens durante o combate."
+L["CONFIRM_ERASE"] = "Excluir %s%s?"
+L["BAGS_FULL"] = "Suas bolsas estão cheias!"
+L["BAGS_FULL_NUDGE"] = "Suas bolsas estão quase cheias. Você tem %d espaços restantes."
+L["BAGS_FULL_NUDGE_ONE"] = "Suas bolsas estão quase cheias. Você tem 1 espaço restante."
 L["CURSOR_TOO_FAST"] = "Devagar! Você está clicando mais rápido do que o jogo consegue excluir itens."
 L["ERASED_ITEM"] = "%s%s%s excluído."
 L["ERASED_VALUE_SUFFIX"] = ", valor %s"
 L["ERASED_QUEST_SUFFIX"] = ", este item estava associado a uma missão concluída"
 L["QUEST_ITEM_READY"] = "%s agora pode ser excluído com segurança!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "O Magic Eraser vai excluir isto."
+L["TOOLTIP_IGNORED"] = "Protegido pela sua lista de ignorados."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s vendido, valor %s."
+L["SOLD_SUMMARY"] = "%s itens vendidos, valor %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "A venda automática ocorrerá assim que o combate terminar."
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "A venda automática ocorrerá assim que o comb
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Item de menor valor"
+L["CLUTTER_REPORT"] = "Relatório de lixo"
+L["CLUTTER_SLOTS"] = "%s espaços"
+L["CLUTTER_ITEMS"] = "(%s itens)"
+L["CLUTTER_VALUE"] = "Valor %s"
 L["NO_VALUE"] = "Sem valor"
 L["LEFT_CLICK"] = "Clique esquerdo"
 L["RIGHT_CLICK"] = "Clique direito"
@@ -62,15 +76,41 @@ L["OFF"] = "Desativado"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Limpe suas bolsas instantaneamente. Itens de missões concluídas, consumíveis de baixo nível, itens brancos de qualidade de vendedor e lixo cinza são excluídos a cada clique no botão do minimapa. Quando você visita um mercante, tudo o que pode ser vendido é vendido automaticamente."
+L["OPTIONS_DESCRIPTION"] =
+	"Limpe suas bolsas instantaneamente. Itens de missões concluídas, consumíveis de baixo nível, itens brancos de qualidade de vendedor e lixo cinza são excluídos a cada clique no botão do minimapa. Quando você visita um mercante, tudo o que pode ser vendido é vendido automaticamente."
 L["OPTIONS_WELCOME"] = "Ativar mensagem de boas-vindas"
 L["OPTIONS_MINIMAP"] = "Ativar botão do minimapa"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Vende automaticamente itens marcados como lixo pelo Magic Eraser ao abrir uma janela de mercador."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Abre a interface de opções do Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Dicas de itens"
+L["OPTIONS_TOOLTIP_WARNING"] = "Ativar dicas para itens na bolsa"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Vende automaticamente itens marcados como lixo pelo Magic Eraser ao abrir uma janela de mercador."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Ativar Venda automática"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Ativar mensagens de Venda automática"
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Abre a interface de opções do Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "Por item"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Resumo"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Avisos de espaço na bolsa"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Ativar avisos de espaço na bolsa"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Limite de espaços livres"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Confirmações de exclusão"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "Perguntar antes de excluir os tipos de item marcados abaixo."
+L["OPTIONS_ENABLE_SAFETY"] = "Ativar confirmações de exclusão"
+L["OPTIONS_SAFETY_QUEST"] = "Para itens de missões concluídas"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Para consumíveis de baixo nível"
+L["OPTIONS_SAFETY_WHITE"] = "Para itens brancos de qualidade de vendedor"
+L["OPTIONS_SAFETY_GRAY"] = "Para itens cinzas de qualidade de vendedor"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback e suporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -14,18 +14,29 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "Версия %s. Настройки (включая опцию отключения этого сообщения) можно найти в Настройки > Аддоны > Magic Eraser. Нравится аддон? Расскажите другу! (="
+L["CHAT_LOADED"] =
+	"Версия %s. Настройки (включая опцию отключения этого сообщения) можно найти в Настройки > Аддоны > Magic Eraser. Нравится аддон? Расскажите другу! (="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "Нельзя удалять предметы во время боя."
-L["CURSOR_TOO_FAST"] = "Помедленнее! Вы кликаете быстрее, чем игра успевает удалять предметы."
+L["CONFIRM_ERASE"] = "Удалить %s%s?"
+L["BAGS_FULL"] = "Ваши сумки полны!"
+L["BAGS_FULL_NUDGE"] = "Ваши сумки почти полны. Свободных ячеек: %d."
+L["BAGS_FULL_NUDGE_ONE"] = "Ваши сумки почти полны. Свободна 1 ячейка."
+L["CURSOR_TOO_FAST"] =
+	"Помедленнее! Вы кликаете быстрее, чем игра успевает удалять предметы."
 L["ERASED_ITEM"] = "%s%s%s удалён."
 L["ERASED_VALUE_SUFFIX"] = ", стоимость %s"
 L["ERASED_QUEST_SUFFIX"] = ", этот предмет был связан с выполненным заданием"
 L["QUEST_ITEM_READY"] = "%s теперь можно безопасно удалить!"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser удалит этот предмет."
+L["TOOLTIP_IGNORED"] = "Защищён вашим списком игнорируемых."
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "%s%s продан, стоимость %s."
+L["SOLD_SUMMARY"] = "Продано предметов: %s, стоимость %s."
 L["AUTO_VEND_COMBAT_DEFERRED"] = "Автопродажа сработает после окончания боя."
 
 --------------------------------------------------------------------------------
@@ -33,6 +44,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "Автопродажа сработает по
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "Предмет наименьшей ценности"
+L["CLUTTER_REPORT"] = "Отчёт о хламе"
+L["CLUTTER_SLOTS"] = "%s ячеек"
+L["CLUTTER_ITEMS"] = "(%s предметов)"
+L["CLUTTER_VALUE"] = "Стоимость %s"
 L["NO_VALUE"] = "Без ценности"
 L["LEFT_CLICK"] = "Левый клик"
 L["RIGHT_CLICK"] = "Правый клик"
@@ -43,7 +58,8 @@ L["ACTION_IGNORE"] = "Игнорировать"
 L["ACTION_TOGGLE"] = "Переключить"
 L["ACTION_CLEAR_IGNORE"] = "Очистить список игнорируемых"
 L["BAGS_CLEAN_SHORT"] = "Поздравляем, ваши сумки полны полезных вещей!"
-L["BAGS_CLEAN_HINT"] = "Чтобы освободить место, придётся удалить что-нибудь вручную."
+L["BAGS_CLEAN_HINT"] =
+	"Чтобы освободить место, придётся удалить что-нибудь вручную."
 L["LOADING_ITEM"] = "Загрузка ID: %d"
 L["MINIMAP_OPTIONS"] = "Настройки Magic Eraser"
 L["MINIMAP_OPTIONS_KEYBIND"] = "Shift + Средний клик"
@@ -53,7 +69,8 @@ L["MINIMAP_OPTIONS_KEYBIND"] = "Shift + Средний клик"
 --------------------------------------------------------------------------------
 
 L["AUTO_VEND"] = "Автопродажа"
-L["AUTO_VEND_DESCRIPTION"] = "Автоматически продаёт предметы, отмеченные Magic Eraser как мусор."
+L["AUTO_VEND_DESCRIPTION"] =
+	"Автоматически продаёт предметы, отмеченные Magic Eraser как мусор."
 L["IGNORE_LIST"] = "Список игнорируемых"
 L["ON"] = "Включено"
 L["OFF"] = "Выключено"
@@ -62,15 +79,42 @@ L["OFF"] = "Выключено"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "Мгновенно наведите порядок в сумках. Завершенные квестовые предметы, низкоуровневые расходники, белые предметы для продажи и серый мусор удаляются с каждым кликом по кнопке у миникарты. Когда вы посещаете торговца, всё, что можно продать, продаётся автоматически."
+L["OPTIONS_DESCRIPTION"] =
+	"Мгновенно наведите порядок в сумках. Завершённые квестовые предметы, низкоуровневые расходники, белые предметы для продажи и серый мусор удаляются с каждым кликом по кнопке у миникарты. Когда вы посещаете торговца, всё, что можно продать, продаётся автоматически."
 L["OPTIONS_WELCOME"] = "Включить приветственное сообщение"
 L["OPTIONS_MINIMAP"] = "Включить кнопку у миникарты"
-L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "Автоматически продаёт предметы, отмеченные Magic Eraser как мусор, при открытии окна торговца."
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Команды"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "Открывает интерфейс настроек Magic Eraser."
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "Подсказки предметов"
+L["OPTIONS_TOOLTIP_WARNING"] = "Включить подсказки для предметов в сумках"
+
+-- Auto-Vend
+L["OPTIONS_AUTO_VEND_DESCRIPTION"] =
+	"Автоматически продаёт предметы, отмеченные Magic Eraser как мусор, при открытии окна торговца."
 L["OPTIONS_ENABLE_AUTO_VEND"] = "Включить автопродажу"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "Включить сообщения автопродажи"
-L["OPTIONS_COMMANDS_HEADER"] = "/Команды"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "Открывает интерфейс настроек Magic Eraser."
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "По предметам"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "Сводка"
+L["OPTIONS_BAGS_FULL_HEADER"] = "Предупреждения о месте в сумках"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "Включить предупреждения о месте в сумках"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "Порог свободных ячеек"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "Подтверждения удаления"
+L["OPTIONS_SAFETY_DESCRIPTION"] =
+	"Спрашивать перед удалением отмеченных ниже типов предметов."
+L["OPTIONS_ENABLE_SAFETY"] = "Включить подтверждения удаления"
+L["OPTIONS_SAFETY_QUEST"] = "Для предметов выполненных заданий"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "Для низкоуровневых расходников"
+L["OPTIONS_SAFETY_WHITE"] = "Для белых предметов для продажи"
+L["OPTIONS_SAFETY_GRAY"] = "Для серых предметов для продажи"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Обратная связь и поддержка"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "版本 %s。设置（包括关闭此消息的选项）可以在 选项 > 插件 > Magic Eraser 中找到。喜欢这个插件吗？告诉朋友吧！(="
+L["CHAT_LOADED"] =
+	"版本 %s。设置（包括关闭此消息的选项）可以在 选项 > 插件 > Magic Eraser 中找到。喜欢这个插件吗？告诉朋友吧！(="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "战斗中无法删除物品。"
+L["CONFIRM_ERASE"] = "删除 %s%s？"
+L["BAGS_FULL"] = "你的背包已满！"
+L["BAGS_FULL_NUDGE"] = "你的背包快满了。还剩 %d 个空格。"
+L["BAGS_FULL_NUDGE_ONE"] = "你的背包快满了。还剩 1 个空格。"
 L["CURSOR_TOO_FAST"] = "慢一点！你的点击速度超过了游戏删除物品的速度。"
 L["ERASED_ITEM"] = "已删除 %s%s%s。"
 L["ERASED_VALUE_SUFFIX"] = "，价值 %s"
 L["ERASED_QUEST_SUFFIX"] = "，该物品关联的任务已完成"
 L["QUEST_ITEM_READY"] = "%s 现在可以安全删除了！"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser 将删除此物品。"
+L["TOOLTIP_IGNORED"] = "受你的忽略列表保护。"
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "已出售 %s%s，价值 %s。"
+L["SOLD_SUMMARY"] = "已出售 %s 件物品，价值 %s。"
 L["AUTO_VEND_COMBAT_DEFERRED"] = "战斗结束后将执行自动售卖。"
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "战斗结束后将执行自动售卖。"
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "最低价值物品"
+L["CLUTTER_REPORT"] = "杂物报告"
+L["CLUTTER_SLOTS"] = "%s 个格子"
+L["CLUTTER_ITEMS"] = "(%s 件物品)"
+L["CLUTTER_VALUE"] = "价值 %s"
 L["NO_VALUE"] = "无价值"
 L["LEFT_CLICK"] = "左键点击"
 L["RIGHT_CLICK"] = "右键点击"
@@ -62,15 +76,40 @@ L["OFF"] = "已禁用"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "瞬间清理你的背包。每次点击小地图按钮，都会删除已完成的任务物品、低级消耗品、可售卖给商人的白色物品以及灰色垃圾。当你拜访商人时，所有可出售的物品都会自动售出。"
+L["OPTIONS_DESCRIPTION"] =
+	"瞬间清理你的背包。每次点击小地图按钮，都会删除已完成的任务物品、低级消耗品、可售卖给商人的白色物品以及灰色垃圾。当你拜访商人时，所有可出售的物品都会自动售出。"
 L["OPTIONS_WELCOME"] = "启用欢迎消息"
 L["OPTIONS_MINIMAP"] = "启用小地图按钮"
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/命令"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "打开 Magic Eraser 选项界面。"
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "物品提示"
+L["OPTIONS_TOOLTIP_WARNING"] = "为背包内物品启用提示"
+
+-- Auto-Vend
 L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "打开商人窗口时自动出售被 Magic Eraser 标记为垃圾的物品。"
 L["OPTIONS_ENABLE_AUTO_VEND"] = "启用自动售卖"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "启用自动售卖消息"
-L["OPTIONS_COMMANDS_HEADER"] = "/命令"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "打开 Magic Eraser 选项界面。"
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "逐项"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "汇总"
+L["OPTIONS_BAGS_FULL_HEADER"] = "背包空间警告"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "启用背包空间警告"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "空格阈值"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "删除确认"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "在删除下方勾选的物品类型前先询问。"
+L["OPTIONS_ENABLE_SAFETY"] = "启用删除确认"
+L["OPTIONS_SAFETY_QUEST"] = "对已完成任务的物品"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "对低级消耗品"
+L["OPTIONS_SAFETY_WHITE"] = "对可售卖的白色物品"
+L["OPTIONS_SAFETY_GRAY"] = "对可售卖的灰色物品"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "反馈与支持"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -14,18 +14,28 @@ L["ADDON_TITLE"] = "Magic Eraser"
 --------------------------------------------------------------------------------
 
 -- System
-L["CHAT_LOADED"] = "版本 %s。設定（包含關閉此訊息的選項）可以在 選項 > 插件 > Magic Eraser 中找到。喜歡這個插件嗎？告訴朋友吧！(="
+L["CHAT_LOADED"] =
+	"版本 %s。設定（包含關閉此訊息的選項）可以在 選項 > 插件 > Magic Eraser 中找到。喜歡這個插件嗎？告訴朋友吧！(="
 
 -- Eraser
 L["COMBAT_LOCKOUT"] = "戰鬥中無法刪除物品。"
+L["CONFIRM_ERASE"] = "刪除 %s%s？"
+L["BAGS_FULL"] = "你的背包已滿！"
+L["BAGS_FULL_NUDGE"] = "你的背包快滿了。還剩 %d 個空格。"
+L["BAGS_FULL_NUDGE_ONE"] = "你的背包快滿了。還剩 1 個空格。"
 L["CURSOR_TOO_FAST"] = "慢一點！你的點擊速度超過了遊戲刪除物品的速度。"
 L["ERASED_ITEM"] = "已刪除 %s%s%s。"
 L["ERASED_VALUE_SUFFIX"] = "，價值 %s"
 L["ERASED_QUEST_SUFFIX"] = "，該物品關聯的任務已完成"
 L["QUEST_ITEM_READY"] = "%s 現在可以安全刪除了！"
 
+-- Item Tooltip
+L["TOOLTIP_WILL_ERASE"] = "Magic Eraser 將刪除此物品。"
+L["TOOLTIP_IGNORED"] = "受你的忽略清單保護。"
+
 -- Auto-Vend
 L["SOLD_ITEM"] = "已出售 %s%s，價值 %s。"
+L["SOLD_SUMMARY"] = "已出售 %s 件物品，價值 %s。"
 L["AUTO_VEND_COMBAT_DEFERRED"] = "戰鬥結束後將執行自動售賣。"
 
 --------------------------------------------------------------------------------
@@ -33,6 +43,10 @@ L["AUTO_VEND_COMBAT_DEFERRED"] = "戰鬥結束後將執行自動售賣。"
 --------------------------------------------------------------------------------
 
 L["LOWEST_VALUE_ITEM"] = "最低價值物品"
+L["CLUTTER_REPORT"] = "雜物報告"
+L["CLUTTER_SLOTS"] = "%s 個格子"
+L["CLUTTER_ITEMS"] = "(%s 件物品)"
+L["CLUTTER_VALUE"] = "價值 %s"
 L["NO_VALUE"] = "無價值"
 L["LEFT_CLICK"] = "左鍵點擊"
 L["RIGHT_CLICK"] = "右鍵點擊"
@@ -62,15 +76,40 @@ L["OFF"] = "已停用"
 -- Options: Main Panel
 --------------------------------------------------------------------------------
 
-L["OPTIONS_DESCRIPTION"] = "瞬間清理你的背包。每次點擊小地圖按鈕，都會刪除已完成的任務物品、低等級消耗品、可售賣給商人的白色物品以及灰色垃圾。當你拜訪商人時，所有可出售的物品都會自動售出。"
+L["OPTIONS_DESCRIPTION"] =
+	"瞬間清理你的背包。每次點擊小地圖按鈕，都會刪除已完成的任務物品、低等級消耗品、可售賣給商人的白色物品以及灰色垃圾。當你拜訪商人時，所有可出售的物品都會自動售出。"
 L["OPTIONS_WELCOME"] = "啟用歡迎訊息"
 L["OPTIONS_MINIMAP"] = "啟用小地圖按鈕"
+
+-- /Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/指令"
+L["OPTIONS_COMMAND_ERASER"] = "/eraser"
+L["OPTIONS_COMMAND_ERASER_DESCRIPTION"] = "開啟 Magic Eraser 選項介面。"
+
+-- Item Tooltips
+L["OPTIONS_TOOLTIP_HEADER"] = "物品提示"
+L["OPTIONS_TOOLTIP_WARNING"] = "為背包內物品啟用提示"
+
+-- Auto-Vend
 L["OPTIONS_AUTO_VEND_DESCRIPTION"] = "開啟商人視窗時自動出售被 Magic Eraser 標記為垃圾的物品。"
 L["OPTIONS_ENABLE_AUTO_VEND"] = "啟用自動售賣"
 L["OPTIONS_AUTO_VEND_MESSAGES"] = "啟用自動售賣訊息"
-L["OPTIONS_COMMANDS_HEADER"] = "/指令"
-L["OPTIONS_CMD_ERASER"] = "/eraser"
-L["OPTIONS_CMD_ERASER_DESCRIPTION"] = "開啟 Magic Eraser 選項介面。"
+L["OPTIONS_AUTO_VEND_VERBOSE"] = "逐項"
+L["OPTIONS_AUTO_VEND_SUMMARY"] = "彙總"
+L["OPTIONS_BAGS_FULL_HEADER"] = "背包空間警告"
+L["OPTIONS_BAGS_FULL_NUDGE"] = "啟用背包空間警告"
+L["OPTIONS_BAGS_FULL_THRESHOLD"] = "空格閾值"
+
+-- Eraser Confirmation
+L["OPTIONS_SAFETY_HEADER"] = "刪除確認"
+L["OPTIONS_SAFETY_DESCRIPTION"] = "在刪除下方勾選的物品類型前先詢問。"
+L["OPTIONS_ENABLE_SAFETY"] = "啟用刪除確認"
+L["OPTIONS_SAFETY_QUEST"] = "對已完成任務的物品"
+L["OPTIONS_SAFETY_CONSUMABLE"] = "對低等級消耗品"
+L["OPTIONS_SAFETY_WHITE"] = "對可售賣的白色物品"
+L["OPTIONS_SAFETY_GRAY"] = "對可售賣的灰色物品"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "回饋與支援"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/MagicEraser.toc
+++ b/MagicEraser.toc
@@ -65,6 +65,7 @@ Features/Core.lua
 Features/Utilities.lua
 Features/Announcements.lua
 Features/Auto-Vend.lua
+Features/Item-Tooltips.lua
 Features/Diagnostics.lua
 Features/Minimap-Button.lua
 Options/Options-Utilities.lua

--- a/Options/Options-General.lua
+++ b/Options/Options-General.lua
@@ -1,7 +1,11 @@
-local _, ns = ...
+local ADDON_NAME, ns = ...
 local L = ns.L
 
 local GetColor = ns.GetColor
+
+-- Leading indent that marks a checkbox as a sub-option of the one above it.
+-- Kept white (not grayed) so it reads as nested rather than disabled.
+local SUB_INDENT = "      "
 
 --------------------------------------------------------------------------------
 -- General Panel
@@ -21,10 +25,10 @@ function ns.BuildGeneralOptions()
 				width = "full",
 				order = 6,
 				get = function()
-					return ns.db and ns.db.profile.showWelcome
+					return ns.db and ns.db.global.showWelcome
 				end,
 				set = function(_, value)
-					ns.db.profile.showWelcome = value
+					ns.db.global.showWelcome = value
 				end,
 			},
 			toggleMinimap = {
@@ -38,20 +42,47 @@ function ns.BuildGeneralOptions()
 				set = function(_, value)
 					ns.db.global.minimap.hide = not value
 					if value then
-						LibStub("LibDBIcon-1.0"):Show("MagicEraser")
+						LibStub("LibDBIcon-1.0"):Show(ADDON_NAME)
 					else
-						LibStub("LibDBIcon-1.0"):Hide("MagicEraser")
+						LibStub("LibDBIcon-1.0"):Hide(ADDON_NAME)
 					end
 				end,
 			},
-
 			spacerCommands0 = ns.OptionsSpacer(20),
 			headerCommands = ns.OptionsHeader(L["OPTIONS_COMMANDS_HEADER"], 21),
 			spacerCommands1 = ns.OptionsSpacer(22),
 			descCommands = ns.OptionsDesc(
-				GetColor("INFO") .. L["OPTIONS_CMD_ERASER"] .. "|r" .. "  " .. L["OPTIONS_CMD_ERASER_DESCRIPTION"],
+				GetColor("INFO")
+					.. L["OPTIONS_COMMAND_ERASER"]
+					.. "|r"
+					.. "  "
+					.. L["OPTIONS_COMMAND_ERASER_DESCRIPTION"],
 				23
 			),
+
+			spacerTooltip0 = ns.OptionsSpacer(24),
+			headerTooltip = ns.OptionsHeader(L["OPTIONS_TOOLTIP_HEADER"], 25),
+			spacerTooltip1 = ns.OptionsSpacer(26),
+			--[[
+				A live sample of the tooltip line, composed exactly as
+				Features/Item-Tooltips.lua renders the Ignore List protection notice
+				(ns.BrandPrefix + a colored body), so the panel shows the real line
+				a player sees on a protected item.
+			]]
+			exampleTooltip = ns.OptionsDesc(ns.BrandPrefix .. GetColor("TEXT") .. L["TOOLTIP_IGNORED"] .. "|r", 27),
+			spacerTooltip2 = ns.OptionsSpacer(28),
+			toggleTooltipWarning = {
+				type = "toggle",
+				name = L["OPTIONS_TOOLTIP_WARNING"],
+				width = "full",
+				order = 29,
+				get = function()
+					return ns.db and ns.db.global.tooltipWarningEnabled
+				end,
+				set = function(_, value)
+					ns.db.global.tooltipWarningEnabled = value
+				end,
+			},
 
 			spacerAutoVend0 = ns.OptionsSpacer(30),
 			headerAutoVend = ns.OptionsHeader(L["AUTO_VEND"], 31),
@@ -64,25 +95,172 @@ function ns.BuildGeneralOptions()
 				width = "full",
 				order = 35,
 				get = function()
-					return ns.db and ns.db.profile.autoVendEnabled
+					return ns.db and ns.db.global.autoVendEnabled
 				end,
 				set = function(_, value)
-					ns.db.profile.autoVendEnabled = value
+					ns.db.global.autoVendEnabled = value
 				end,
 			},
 			toggleAutoVendMessages = {
 				type = "toggle",
-				name = L["OPTIONS_AUTO_VEND_MESSAGES"],
-				width = "full",
+				name = SUB_INDENT .. L["OPTIONS_AUTO_VEND_MESSAGES"],
+				width = "double",
 				order = 36,
 				hidden = function()
-					return not (ns.db and ns.db.profile.autoVendEnabled)
+					return not (ns.db and ns.db.global.autoVendEnabled)
 				end,
 				get = function()
-					return ns.db and ns.db.profile.autoVendMessagesEnabled
+					return ns.db and ns.db.global.autoVendMessagesEnabled
 				end,
 				set = function(_, value)
-					ns.db.profile.autoVendMessagesEnabled = value
+					ns.db.global.autoVendMessagesEnabled = value
+				end,
+			},
+			selectAutoVendMessageMode = {
+				type = "select",
+				name = "",
+				width = "normal",
+				order = 37,
+				values = {
+					verbose = L["OPTIONS_AUTO_VEND_VERBOSE"],
+					summary = L["OPTIONS_AUTO_VEND_SUMMARY"],
+				},
+				sorting = { "verbose", "summary" },
+				hidden = function()
+					return not (ns.db and ns.db.global.autoVendEnabled)
+				end,
+				disabled = function()
+					return not (ns.db and ns.db.global.autoVendMessagesEnabled)
+				end,
+				get = function()
+					return (ns.db and ns.db.global.autoVendSummaryEnabled) and "summary" or "verbose"
+				end,
+				set = function(_, value)
+					ns.db.global.autoVendSummaryEnabled = (value == "summary")
+				end,
+			},
+
+			spacerBagsFull0 = ns.OptionsSpacer(40),
+			headerBagsFull = ns.OptionsHeader(L["OPTIONS_BAGS_FULL_HEADER"], 41),
+			spacerBagsFull1 = ns.OptionsSpacer(42),
+			--[[
+			    A live sample of the warning, composed exactly as PrintMessage
+			    renders it (ns.BrandPrefix + TEXT-colored body) so the panel shows
+			    the real chat line. Built from the same BAGS_FULL_NUDGE string the
+			    warning uses -- with a stand-in count of 3 -- so the example tracks
+			    any future wording change instead of drifting from it.
+			]]
+			exampleBagsFull = ns.OptionsDesc(
+				ns.BrandPrefix .. GetColor("TEXT") .. string.format(L["BAGS_FULL_NUDGE"], 3) .. "|r",
+				43
+			),
+			spacerBagsFull2 = ns.OptionsSpacer(44),
+			toggleBagsFullNudge = {
+				type = "toggle",
+				name = L["OPTIONS_BAGS_FULL_NUDGE"],
+				width = "full",
+				order = 45,
+				get = function()
+					return ns.db and ns.db.global.bagsFullNudgeEnabled
+				end,
+				set = function(_, value)
+					ns.db.global.bagsFullNudgeEnabled = value
+				end,
+			},
+			rangeBagsFullThreshold = {
+				type = "range",
+				name = L["OPTIONS_BAGS_FULL_THRESHOLD"],
+				width = "full",
+				order = 46,
+				min = 1,
+				max = 10,
+				step = 1,
+				hidden = function()
+					return not (ns.db and ns.db.global.bagsFullNudgeEnabled)
+				end,
+				get = function()
+					return ns.db and ns.db.global.bagsFullThreshold
+				end,
+				set = function(_, value)
+					ns.db.global.bagsFullThreshold = value
+				end,
+			},
+
+			spacerSafety0 = ns.OptionsSpacer(60),
+			headerSafety = ns.OptionsHeader(L["OPTIONS_SAFETY_HEADER"], 61),
+			spacerSafety1 = ns.OptionsSpacer(62),
+			descSafety = ns.OptionsDesc(L["OPTIONS_SAFETY_DESCRIPTION"], 63),
+			spacerSafety2 = ns.OptionsSpacer(64),
+			toggleSafety = {
+				type = "toggle",
+				name = GetColor("TEXT") .. L["OPTIONS_ENABLE_SAFETY"] .. "|r",
+				width = "full",
+				order = 65,
+				get = function()
+					return ns.db and ns.db.global.safetyEnabled
+				end,
+				set = function(_, value)
+					ns.db.global.safetyEnabled = value
+				end,
+			},
+			toggleSafetyQuest = {
+				type = "toggle",
+				name = SUB_INDENT .. L["OPTIONS_SAFETY_QUEST"],
+				width = "full",
+				order = 66,
+				hidden = function()
+					return not (ns.db and ns.db.global.safetyEnabled)
+				end,
+				get = function()
+					return ns.db and ns.db.global.safetyQuest
+				end,
+				set = function(_, value)
+					ns.db.global.safetyQuest = value
+				end,
+			},
+			toggleSafetyConsumable = {
+				type = "toggle",
+				name = SUB_INDENT .. L["OPTIONS_SAFETY_CONSUMABLE"],
+				width = "full",
+				order = 67,
+				hidden = function()
+					return not (ns.db and ns.db.global.safetyEnabled)
+				end,
+				get = function()
+					return ns.db and ns.db.global.safetyConsumable
+				end,
+				set = function(_, value)
+					ns.db.global.safetyConsumable = value
+				end,
+			},
+			toggleSafetyWhite = {
+				type = "toggle",
+				name = SUB_INDENT .. L["OPTIONS_SAFETY_WHITE"],
+				width = "full",
+				order = 68,
+				hidden = function()
+					return not (ns.db and ns.db.global.safetyEnabled)
+				end,
+				get = function()
+					return ns.db and ns.db.global.safetyWhite
+				end,
+				set = function(_, value)
+					ns.db.global.safetyWhite = value
+				end,
+			},
+			toggleSafetyGray = {
+				type = "toggle",
+				name = SUB_INDENT .. L["OPTIONS_SAFETY_GRAY"],
+				width = "full",
+				order = 69,
+				hidden = function()
+					return not (ns.db and ns.db.global.safetyEnabled)
+				end,
+				get = function()
+					return ns.db and ns.db.global.safetyGray
+				end,
+				set = function(_, value)
+					ns.db.global.safetyGray = value
 				end,
 			},
 

--- a/README-Technical.md
+++ b/README-Technical.md
@@ -12,25 +12,25 @@ Magic-Eraser/
 ├── .pkgmeta                    Externals and ignore list.
 ├── .gitignore
 ├── LICENSE                     MIT.
-├── MagicEraser.toc             Single TOC; dual interface (11508 Classic Era, 20505 TBC).
+├── MagicEraser.toc             Single TOC; dual interface (11508 Classic Era, 20506 TBC Anniversary).
 ├── README.md                   Player-facing documentation.
 ├── README-Technical.md         This document.
-├── CHANGELOG.md
 ├── Data/
-│   ├── Data.lua                Locale init, identity, version, links, color palette, ns.OPTIONS_REGISTRY, class reagent exclusions, deletion priority. No logic beyond GetLocale/GetVersion.
-│   ├── Default-Settings.lua    ns.DEFAULT_CONFIGURATION — account and per-character defaults.
-│   ├── Quest-Items.lua         ns.AllowedDeleteQuestItems: itemId → { questId, ... } release map.
-│   ├── Consumables.lua         ns.AllowedDeleteConsumables: itemId → true, vendor-trash consumables.
+│   ├── Data.lua                Locale init, identity, ns.Links, ns.OPTIONS_REGISTRY, color palette, class reagent exclusions, deletion priority. No logic beyond GetLocale.
+│   ├── Default-Settings.lua    ns.DATABASE_DEFAULTS — the AceDB defaults table (global + profile scopes).
+│   ├── Quest-Items.lua         ns.AllowedDeleteQuestItems: itemId → { questId, ... }.
+│   ├── Consumables.lua         ns.AllowedDeleteConsumables: itemId → true, outgrown food/drink.
 │   └── Equipment.lua           ns.AllowedDeleteEquipment: itemId → true, vendor-quality whites.
 ├── Features/
-│   ├── Core.lua                Central event dispatcher, saved-variable lifecycle, scan/evaluate/rank/erase pipeline, scan cache, ignore list.
+│   ├── Core.lua                Event dispatcher, saved-variable lifecycle + migrations, scan/evaluate/rank/erase pipeline, scan cache, ignore list, bag-space warning.
 │   ├── Utilities.lua           Derived COLORS table + ns.GetColor, ns.BrandPrefix, currency/number formatting, ns:IsQuestCompleted.
 │   ├── Announcements.lua       ns:PrintMessage — player-only branded print.
-│   ├── Auto-Vend.lua           Merchant auto-sell (scan-then-process queue). Owns ns:OnMerchantShow / ns:OnMerchantClosed.
+│   ├── Auto-Vend.lua           Merchant auto-sell (scan → queue → process, multi-pass). Owns ns:OnMerchantShow / ns:OnMerchantClosed / ns:OnCombatEnded.
+│   ├── Item-Tooltips.lua       ns.SetupTooltipHooks — appends the will-erase / protected line to bag-item tooltips.
 │   ├── Diagnostics.lua         Diagnostic Tools: report builders, event log, API/event probes, taint log. Runtime-only, never persisted, strings never localized.
 │   └── Minimap-Button.lua      LDB data object, tooltip composition, click handlers, ns:RefreshDisplay.
 ├── Includes/
-│   ├── Libraries/              Vendored: LibStub, CallbackHandler-1.0, AceLocale-3.0, AceGUI-3.0, AceConfig-3.0 (Registry/Cmd/Dialog), LibDataBroker-1.1, LibDBIcon-1.0.
+│   ├── Libraries/              Vendored: LibStub, CallbackHandler-1.0, AceLocale-3.0, AceDB-3.0, AceGUI-3.0, AceConfig-3.0 (Registry/Cmd/Dialog), AceDBOptions-3.0, LibDataBroker-1.1, LibDBIcon-1.0.
 │   └── Images/
 │       └── Magic-Eraser.tga    Default minimap icon.
 ├── Locales/
@@ -39,6 +39,7 @@ Magic-Eraser/
 └── Options/
     ├── Options-Utilities.lua   Shared ns.Options* widget constructors.
     ├── Options-General.lua     ns.BuildGeneralOptions — root panel.
+    ├── Options-Profiles.lua    ns.BuildProfilesOptions — stock AceDBOptions-3.0 table, unmodified.
     ├── Options-Diagnostics.lua ns.BuildDiagnosticsOptions — Diagnostic Tools panel.
     └── Options.lua             Panel registration (RegisterOptionsTable + AddToBlizOptions) and the /eraser slash command.
 ```
@@ -47,35 +48,38 @@ Magic-Eraser/
 
 ### Event Loop
 
-Every event routes through a single frame in `Core.lua`. `ns.EVENT_NAMES` is the one source of truth: the dispatcher registers each name in it, and `EVENT_HANDLERS` maps each name to an `ns:OnXxx` method resolved *by name at fire time* — so feature files that load after Core supply their own handlers (`Auto-Vend.lua` defines `ns:OnMerchantShow` / `ns:OnMerchantClosed`). Add an event to `ns.EVENT_NAMES` and it is registered, dispatched, and covered by the Diagnostic Tools panel with no second list to maintain.
+Every event routes through a single frame in `Core.lua`. `ns.EVENT_NAMES` is the one source of truth: the dispatcher registers each name in it, and `EVENT_HANDLERS` maps each name to an `ns:OnXxx` method resolved *by name at fire time* — so feature files that load after Core supply their own handlers (`Auto-Vend.lua` defines `ns:OnMerchantShow` / `ns:OnMerchantClosed` / `ns:OnCombatEnded`). Add an event to `ns.EVENT_NAMES` and it is registered, dispatched, and covered by the Diagnostic Tools panel with no second list to maintain.
 
 | Event | Handler | Purpose |
 |-------|---------|---------|
-| `PLAYER_LOGIN` | `ns:OnPlayerLogin` | Saved-variable init, LibDBIcon registration, welcome print. |
+| `PLAYER_LOGIN` | `ns:OnPlayerLogin` | AceDB init, migrations, LibDBIcon registration, welcome print, tooltip-hook install. |
 | `PLAYER_LEVEL_UP` | `ns:OnPlayerLevelUp` | Consumable eligibility is level-gated, so a ding can newly qualify outgrown food — re-scan. |
-| `BAG_UPDATE_DELAYED` | `ns:OnBagUpdateDelayed` | Re-scan + refresh the minimap candidate. |
+| `BAG_UPDATE_DELAYED` | `ns:OnBagUpdateDelayed` | Debounced re-scan + minimap refresh + bag-space check. |
 | `QUEST_TURNED_IN` | `ns:OnQuestTurnedIn` | Quest-item-ready chat alert. |
-| `MERCHANT_SHOW` / `MERCHANT_CLOSED` | `ns:OnMerchantShow` / `ns:OnMerchantClosed` | Start/stop Auto-Vend. |
-| `PLAYER_REGEN_ENABLED` | `ns:OnCombatEnded` | Resume a vend pass that was deferred because it began in combat. |
+| `MERCHANT_SHOW` / `MERCHANT_CLOSED` | `ns:OnMerchantShow` / `ns:OnMerchantClosed` | Start Auto-Vend / flush summary + re-check bag space. |
+| `MAIL_CLOSED` | `ns:OnMailClosed` | Re-check bag space once mail looting settles. |
+| `PLAYER_REGEN_ENABLED` | `ns:OnCombatEnded` | Resume a vend pass deferred because it began in combat. |
 
-`BAG_UPDATE_DELAYED` is debounced with a 0.1s `C_Timer.After` behind the `updatePending` flag, so a burst of updates from looting or a vendor turn-in coalesces into one rescan. `QUEST_TURNED_IN` work is delayed 1.0s to give the server time to flag the quest complete before `IsQuestFlaggedCompleted` is read.
+`BAG_UPDATE_DELAYED` is debounced with a 0.1s `C_Timer.After` behind the `updatePending` flag, so a burst from looting or a vendor turn-in coalesces into one rescan. `QUEST_TURNED_IN` work is delayed 1.0s to give the server time to flag the quest complete before `IsQuestFlaggedCompleted` is read.
 
 The dispatcher taps the diagnostics event log *before* calling the handler, behind a single boolean check (`ns.diagnostics.logging`) so it costs nothing when logging is off. Because every event passes through this one point, the event log is complete — a feature that created its own event frame would bypass the tap and go unlogged.
 
 ### Combat Lockdown
 
-`RunEraser` checks `InCombatLockdown()` at entry and bails with `L["COMBAT_LOCKOUT"]`. There is no deferred replay — the player clicks again after combat.
+`RunEraser` and `PerformErase` check `InCombatLockdown()` at entry and bail with `L["COMBAT_LOCKOUT"]` (`DeleteCursorItem` and `PickupContainerItem` are protected). There is no deferred replay — the player clicks again after combat. `PerformErase` re-guards on entry because a safety confirmation dialog can span the moment combat begins.
 
-Auto-Vend *does* face combat: a merchant frame can be open while in combat (combat starting with the window already open, or lingering combat tags), and `UseContainerItem` is protected, so calling it under lockdown throws `ADDON_ACTION_FORBIDDEN`. Auto-Vend therefore guards in two places — `ns:OnMerchantShow` (opened in combat) and each `ProcessSellQueue` tick (combat started mid-queue) — and on either it stops, sets `vendPending`, and announces the deferral once via `PrintVendMessage` (see Auto-Vend). `ns:OnCombatEnded` (`PLAYER_REGEN_ENABLED`) then re-scans from scratch and resumes if the merchant is still open, since slots may have shifted during combat. `MERCHANT_CLOSED` clears `vendPending`.
+Auto-Vend faces combat differently: a merchant frame can be open while in combat, and `UseContainerItem` is protected, so calling it under lockdown throws `ADDON_ACTION_FORBIDDEN`. Auto-Vend guards in two places — `ns:OnMerchantShow` (opened in combat) and each `ProcessSellQueue` tick (combat started mid-queue) — and on either it stops, sets `vendPending`, and announces the deferral once via `PrintVendMessage`. `ns:OnCombatEnded` (`PLAYER_REGEN_ENABLED`) then re-scans from scratch and resumes if the merchant is still open, since slots may have shifted during combat. `MERCHANT_CLOSED` clears `vendPending`.
 
 ### Scan → Evaluate → Rank → Erase
 
 The pipeline lives in `Core.lua`:
 
 1. **Scan** — `FindItemToDelete` walks bags 0–4 via `C_Container.GetContainerItemInfo`, skipping items on the per-character ignore list and in the class reagent exclusions.
-2. **Evaluate** — `GetItemDeleteReason` returns `"quest"`, `"consumable"`, `"equipment"`, `"gray"`, or `nil` from the three databases plus a rarity-0 / positive-sell-price gray fallback. Quest items must additionally pass `IsQuestCompleted`; consumables must be at least 10 levels below the player.
-3. **Rank** — `isBetterDeletionCandidate` ranks by total stack value first; ties break by `ns.DeletePriority` (`quest=1`, `gray=2`, `consumable=3`, `equipment=3`).
-4. **Erase** — `RunEraser` performs `PickupContainerItem` → `GetCursorInfo` verification → `DeleteCursorItem`, plays a sound, prints the result, invalidates the cache, and refreshes the display after 0.2s.
+2. **Evaluate** — `GetItemDeleteReason` returns `"quest"`, `"consumable"`, `"equipment"`, `"gray"`, or `nil`. Quest items must additionally pass `IsQuestCompleted`; consumables must be at least 10 levels below the player.
+3. **Rank** — `isBetterDeletionCandidate` ranks by total stack value first; ties break by `ns.DeletePriority` (`quest=1`, `gray=2`, `consumable=3`, `equipment=3`), so the cheapest item wins and a completed quest item breaks a value tie.
+4. **Erase** — `RunEraser` (optionally behind a safety confirmation) calls `PerformErase`: `PickupContainerItem` → `GetCursorInfo` verification → `DeleteCursorItem`, plays a sound, prints the result, invalidates the cache, and refreshes the display after 0.2s.
+
+The same single scan populates the tooltip's Clutter Report totals (`cachedReclaimSlots/Items/Value`) as a side effect, read back via `ns:GetReclaimSummary`.
 
 ### Item Data Caching
 
@@ -83,13 +87,17 @@ The pipeline lives in `Core.lua`:
 
 The eraser also keeps a short-lived candidate cache (`cachedItem` + `isCacheValid`) invalidated on bag update, level-up, ignore-list change, deletion, and quest turn-in.
 
+### Per-Character State Inside a Shared Profile
+
+The ignore list is the one per-character setting, but it lives inside the AceDB **profile** rather than a character scope. `profile.ignoreLists` is a table keyed by `ns.db.keys.char` (`"Name - Realm"`); `ns:GetIgnoreList` lazily creates the bucket for the current character on first use. This keeps every toon's list disjoint (distinct char keys never collide) while letting a single shared "Default" profile hold them all — so switching profiles swaps the entire set of per-toon lists at once, and a "Farming" profile can carry its own. Everything else is account-wide under `global`, untouched by profile switches. Registered `OnProfileChanged` / `OnProfileCopied` callbacks re-scan immediately so the candidate reflects the newly active list.
+
 ### Colors
 
-The raw hex palette is data (`ns.PALETTE` in `Data/Data.lua`); the derived escape strings (`COLORS`) and the accessor (`ns.GetColor`) are logic (`Features/Utilities.lua`). `COLORS` is file-local — consumers never read it directly. Each consuming file aliases the accessor once (`local GetColor = ns.GetColor`) and calls `GetColor("KEY")`. Keys: `TITLE`, `INFO`, `BODY`, `TEXT`, `ON`, `OFF`, `SEPARATOR`, `MUTED`.
+The raw hex palette is data (`ns.PALETTE` in `Data/Data.lua`); the derived escape strings (`COLORS`) and the accessor (`ns.GetColor`) are logic (`Features/Utilities.lua`). `COLORS` is file-local — consumers never read it directly. Each consuming file aliases the accessor once (`local GetColor = ns.GetColor`) and calls `GetColor("KEY")`. Keys: `TITLE`, `INFO`, `BODY`, `TEXT`, `ON`, `OFF`, `SEPARATOR`, `MUTED`. Color constants carry no `|cff` prefix — it is prepended once in Utilities, and `|r` is appended at each call site.
 
-## Eraser Pipeline
+## Eraser Categories
 
-The four-category logic in `GetItemDeleteReason` is an ordered fall-through, so an item appearing in two databases is classified by the first match:
+`GetItemDeleteReason` is an ordered fall-through, so an item appearing in two databases is classified by the first match:
 
 ```lua
 if questItemDatabase[itemId] then        -- a completed quest releases it
@@ -98,67 +106,104 @@ elseif equipmentDatabase[itemId] then    -- curated vendor-white
 elseif rarity == 0 and sellPrice > 0     -- generic gray fallback
 ```
 
-Quest data is `itemId → { questId, ... }`; an item is erasable if **any** listed quest is flagged complete, which handles a single drop tied to multiple quests across a chain. There is no "Are you sure?" dialog — `DeleteCursorItem` deletes outright; the safety model is the hand-curated lists, and the player opts in per click. Auto-Vend reuses the same evaluation, so any change to the categories applies to both deletion and vending.
+Quest data is `itemId → { questId, ... }`; an item is erasable if **any** listed quest is flagged complete, which handles one drop tied to multiple quests across a chain. Auto-Vend reuses the exact same evaluation, so any change to the categories applies to both deletion and vending.
+
+## Safety Confirmations
+
+Erasing is normally a single click with no prompt — the safety model is the hand-curated databases. When the player opts in (**Eraser Confirmations**, off by default), `ns:NeedsSafetyConfirm` maps the candidate's delete reason to its per-reason toggle through `SAFETY_REASON_KEYS` (`quest→safetyQuest`, `consumable→safetyConsumable`, `equipment→safetyWhite`, `gray→safetyGray`). When both the master toggle and the matching per-reason toggle are on, `RunEraser` shows the `MAGICERASER_CONFIRM_ERASE` static popup instead of erasing directly. The candidate is passed as the dialog's `data` so each showing acts on the exact item the player saw, and `PerformErase` re-validates the slot (cursor item id must match) before deleting — a slot that shifted while the dialog was open aborts rather than deleting the wrong item. `preferredIndex = 3` avoids tainting the shared dialog stack.
 
 ## Auto-Vend
 
-Auto-Vend is a separate, opt-in feature (`MagicEraserCharDB.autoVendEnabled`) in `Auto-Vend.lua`. It uses a two-stage scan-then-process pattern rather than selling inside the scan:
+Auto-Vend is a separate, opt-in feature (`ns.db.global.autoVendEnabled`) in `Auto-Vend.lua`, using a two-stage scan-then-process pattern rather than selling inside the scan:
 
-1. `ScanAndVend` walks bags, applies the same ignore-list and class-reagent filters as the eraser, and queues every item with a positive `sellPrice` and a non-nil `GetItemDeleteReason`. Once built, the queue is sorted by total stack value ascending (`table.sort`), so the cheapest items sell first.
-2. `ProcessSellQueue` advances one item per 0.1s tick (`C_Timer.After`) and re-reads the slot before selling, because bag positions shift after a sale. The interval paces sales so the merchant frame keeps up; raise it if the server starts dropping sales under load.
+1. `ScanAndVend` walks bags, applies the same ignore-list and class-reagent filters as the eraser, and queues every item with a positive `sellPrice` and a non-nil `GetItemDeleteReason`. The queue is then sorted by total stack value ascending, so the cheapest items sell first.
+2. `ProcessSellQueue` advances one item per 0.1s tick and re-reads the slot before selling, because bag positions shift after a sale.
 
-Items with `sellPrice == 0` (most quest items) are filtered at scan time — they cannot be vendored, so the eraser handles them instead. `MERCHANT_CLOSED` flips `isSelling` false and the next tick wipes the queue.
+**Multi-pass re-sell.** The server silently drops some `UseContainerItem` sells when many arrive in quick succession, leaving one or two flagged items behind on large batches. After a pass finishes, Auto-Vend re-scans and runs another pass (up to `MAX_VEND_PASSES` = 4), rebuilding the queue from live bag state so only items that did not actually sell get re-queued. The cap prevents a flagged-but-unsellable item from looping forever.
 
-All Auto-Vend chat output — the per-item `L["SOLD_ITEM"]` line and the `L["AUTO_VEND_COMBAT_DEFERRED"]` notice — routes through the file-local `PrintVendMessage`, which is a no-op unless `MagicEraserCharDB.autoVendMessagesEnabled` is set. Turning off **Enable Auto-Vend Messages** silences the feature's chat without changing what it sells. The toggle is hidden in the options panel while Auto-Vend itself is disabled.
+**Message modes.** All Auto-Vend chat routes through the file-local `PrintVendMessage`, a no-op unless `ns.db.global.autoVendMessagesEnabled` is set. With messages on, the **Verbose/Summary** dropdown (`autoVendSummaryEnabled`) chooses between a per-item `L["SOLD_ITEM"]` line as each sale lands (Verbose) and a single `L["SOLD_SUMMARY"]` line flushed on `MERCHANT_CLOSED` (Summary). Per-visit totals (`summaryCount` / `summaryValue`) accrue for every newly announced sale regardless of the current mode, so flipping the dropdown mid-visit still produces a correct closing line. `announcedSales`, keyed `"bag:slot:itemId"`, dedups the per-item line so a retry pass that re-sells a silently-dropped slot only announces it once; it is wiped per visit in `StartVending`, not per pass.
+
+Items with `sellPrice == 0` (most quest items) are filtered at scan time — they cannot be vendored, so the eraser handles them instead.
+
+## Item Tooltip Warnings
+
+`Features/Item-Tooltips.lua` appends a single branded line to a carried-bag item's tooltip: a red will-erase warning (`L["TOOLTIP_WILL_ERASE"]`) when Magic Eraser would erase it, or a green protection notice (`L["TOOLTIP_IGNORED"]`) when the Ignore List is shielding it. The verdict comes from the very rules the eraser's scan uses (`ns:IsIgnored`, class-reagent exclusions, `ns:GetItemDeleteReason`), so the line appears only when the item truly would be erased — level gate and quest-completion check included. Purely read-only; gated on `tooltipWarningEnabled`.
+
+There are two hook paths because the tooltip API differs across the flavors we target, and only one is ever active (the line is never doubled):
+
+- **Modern** clients expose `TooltipDataProcessor`; the post-call fires for every item tooltip, so `IsCarriedBagSlot` filters to owners whose `GetBagID()` (or `ContainerFrame` parent id) is in `0..NUM_BAG_SLOTS`.
+- **Older** clients get a `hooksecurefunc` on `GameTooltip:SetBagItem`, already bag-scoped by its arguments.
+
+Hooks install from `ns:OnPlayerLogin` via `C_Timer.After(0, ns.SetupTooltipHooks)`, not at file load, so ours wraps the **outermost** layer other add-ons installed. A heavy tooltip add-on like TSM that clears and re-fills the tooltip in its own `OnTooltipSetItem` would otherwise wipe our line; landing last, we survive its rebuild (and on the `SetBagItem` path we re-`Show()` so the frame grows to include the added line).
+
+## Bag-Space Warnings
+
+An opt-in countdown (`bagsFullNudgeEnabled`, off by default) that warns as free slots drop to or below `bagsFullThreshold`. It never deletes and does not care whether anything is erasable — it is purely a free-space alert. `CountFreeSlots` sums only general bags, excluding specialty bags (quiver/soul/profession) since ordinary loot can't go there. `lastNudgeFree` dedups so the same count is never printed twice in a row, and resets once free climbs back above the threshold so re-entering the warning zone warns again.
+
+Warnings are suppressed while a merchant or mailbox window is open (`IsBagWindowOpen`, checked live rather than via a tracked flag), because those visits churn bags hardest and any count would be stale the moment the window closes. `OnMerchantClosed` and `OnMailClosed` re-check once on close so the warning reflects where the bags actually landed. The baseline is seeded at login (`lastNudgeFree = CountFreeSlots()`) so the login-time `BAG_UPDATE_DELAYED` burst — the client populating bags on load — is treated as already known and doesn't warn about space you arrived with.
 
 ## Quest-Item Alerts
 
-`ns:OnQuestTurnedIn` waits 1.0s, then walks bags and prints `L["QUEST_ITEM_READY"]` for each held item whose newly-completed quest matches one of its tracked ids. This is purely a UX nudge — the eraser's own evaluation already classifies the same items.
+`ns:OnQuestTurnedIn` waits 1.0s, then walks bags and prints `L["QUEST_ITEM_READY"]` once per held item whose newly-completed quest matches one of its tracked ids. Purely a UX nudge — the eraser's own evaluation already classifies the same items.
 
-## Minimap Button
+## Minimap Button & Display
 
-`Minimap-Button.lua` builds an LDB data object whose icon mirrors the current erase candidate. Click handlers: left = `RunEraser`, right = toggle the current candidate on the ignore list, middle = clear the ignore list, shift + right = toggle Auto-Vend. `ns:RefreshDisplay` invalidates the cache, recomputes the candidate, repoints the icon, and re-renders the tooltip if the button currently owns it.
+`Minimap-Button.lua` builds an LDB data object (registered with LibDBIcon) whose icon mirrors the current erase candidate, falling back to `ns.DefaultIcon` when bags are clean. Click handlers:
 
-## Slash Command
+| Click | Action |
+|-------|--------|
+| Left | `RunEraser` — erase the lowest-value candidate. |
+| Right | Toggle the current candidate on the ignore list. |
+| Middle | Clear the ignore list. |
+| Shift + Right | Toggle Auto-Vend. |
+| Shift + Middle | Open the options panel. |
 
-`/eraser` opens the options panel. Registration lives in `Options/Options.lua` (`SLASH_MAGICERASER1` + `SlashCmdList.MAGICERASER`); the handler is the file-local `OpenOptions`, which walks a three-tier fallback so it works across client versions:
-
-1. `Settings.OpenToCategory` — modern Settings API.
-2. `InterfaceOptionsFrame_OpenToCategory`, called twice — legacy quirk where the first call only scrolls the tree and the second actually opens the panel.
-3. `AceConfigDialog:Open` — last resort.
-
-The category is looked up by `ns.AddonTitle`, the same name passed to `AddToBlizOptions`, so registration and lookup stay in sync. The command is surfaced to players under the panel's **/Commands** header (`L["OPTIONS_COMMANDS_HEADER"]` + `L["OPTIONS_CMD_ERASER"]`).
+`RefreshTooltip` composes the whole tooltip — Clutter Report (or a clean-bags congratulations), the lowest-value item with click hints, Auto-Vend status, the per-character ignore list (item names resolved lazily, `LOADING_ITEM` shown for cold ones), and the options keybind. `ns:RefreshDisplay` invalidates the cache, recomputes the candidate, repoints the icon, and re-renders the tooltip if the button currently owns it.
 
 ## Diagnostic Tools
 
-`Features/Diagnostics.lua` plus `Options/Options-Diagnostics.lua` provide a gated panel at **Options > AddOns > Magic Eraser > Diagnostic Tools** for bug reports — environment probing and state capture, not unit tests. State lives in `ns.diagnostics` (`{ enabled, logging, log }`), never in SavedVariables, so it defaults off and resets every session. Sections:
+`Features/Diagnostics.lua` plus `Options/Options-Diagnostics.lua` provide a gated panel at **Options > AddOns > Magic Eraser > Diagnostic Tools** for bug reports — environment probing and state capture, not unit tests. State lives in `ns.diagnostics` (`{ enabled, logging, log }`), a plain namespace table that is never a SavedVariable, so it defaults off and resets every session. Every report builds only on a button press, never on load or panel open. Sections:
 
-- **Event Registration** — every `ns.EVENT_NAMES` entry tested for `C_EventUtils.IsEventValid` and a register/unregister round-trip.
-- **API Endpoints** — `ns.DIAGNOSTIC_API_CHECKS`, kept one-to-one with the APIs the add-on actually calls; existence/shape checks only.
-- **Event Log** — the dispatcher tap, capped ring buffer; `ns.DIAGNOSTIC_EVENT_EXCLUDE` drops firehose events.
-- **Eraser / Display Context** — the live candidate, database sizes, player level/class, screen size, and minimap placement.
-- **Saved Variables** — both tables dumped; the ignore list is summarized by count.
-- **Library Versions** and **Taint Log** — the taint CVar is the only thing the panel ever writes.
+- **Event Log** — the dispatcher tap, a 500-entry ring buffer capping 8 args × 255 bytes each, pipes escaped so item links paste as plain text. `ns.DIAGNOSTIC_EVENT_EXCLUDE` is deliberately empty (the log only ever sees events the add-on registers).
+- **Event Registration** — every `ns.EVENT_NAMES` entry tested for `C_EventUtils.IsEventValid` and a register/unregister round-trip on a probe frame.
+- **API Endpoints** — `ns.DIAGNOSTIC_API_CHECKS`, kept one-to-one with the APIs the add-on calls or guards; existence/shape checks only.
+- **Eraser / Display Context** — the live candidate, database sizes, player level/class, ignore-list count, screen size, UI scale, and minimap placement.
+- **Saved Variables** — `MagicEraserDB` dumped; each profile's `ignoreLists` is replaced with a per-character count summary rather than every itemId.
+- **Library Versions** and **Taint Log** — the `taintLog` CVar is the only state the panel ever writes (see WRITING USER CVARS).
 
-All diagnostics strings are plain English in the diagnostics files (never localized). The panel is registered last so it sits at the bottom of the settings tree.
+All diagnostics strings are plain English in the diagnostics files, never localized (developer-facing, zero player value). The panel is registered last so it sits at the bottom of the settings tree.
+
+## Options & Profiles
+
+`ns:RegisterOptionsPanels` (called from `OnPlayerLogin`, once `ns.db` exists) registers three AceConfig tables from `ns.OPTIONS_REGISTRY` and nests them under Magic Eraser in Blizzard options, in order: **General** (root) → **Profiles** → **Diagnostic Tools**. Panel content lives in the per-panel builder files; `Options.lua` is registration only. Widget constructors (`ns.OptionsHeader/Desc/Spacer/SubHeader`) are shared from `Options-Utilities.lua`. The **Profiles** panel is the stock `AceDBOptions-3.0` table returned unmodified.
+
+`/eraser` opens the options panel. Registration is in `Options.lua` (`SLASH_MAGICERASER1` + `SlashCmdList.MAGICERASER`); the handler `ns:OpenOptionsPanel` walks a three-tier fallback so it works across client versions: `Settings.OpenToCategory` (modern), then `InterfaceOptionsFrame_OpenToCategory` called twice (legacy quirk — first call scrolls the tree, second opens the panel), then `AceConfigDialog:Open`. The category is looked up by `ns.AddonTitle`, the same name passed to `AddToBlizOptions`, so registration and lookup stay in sync.
 
 ## Saved Variables
 
-- **`MagicEraserDB`** (account-wide):
-    - `minimap` — table passed to `LibDBIcon:Register` for button placement.
-    - `showWelcome` — boolean, default `true`.
-- **`MagicEraserCharDB`** (per-character):
-    - `ignoreList` — `itemId → true` map; items added via right-click on the minimap button.
-    - `autoVendEnabled` — boolean, default `false`.
-    - `autoVendMessagesEnabled` — boolean, default `true`; gates all Auto-Vend chat output via `PrintVendMessage`.
+Magic Eraser uses **AceDB-3.0**. There is one managed table, `MagicEraserDB`, initialized in `ns:OnPlayerLogin` with `LibStub("AceDB-3.0"):New("MagicEraserDB", ns.DATABASE_DEFAULTS, true)`:
 
-Defaults live in `ns.DEFAULT_CONFIGURATION` (`Data/Default-Settings.lua`) and are applied by `ApplyDefaults` in `ns:OnPlayerLogin` — a recursive additive merge that seeds a fresh table per scope for table-valued defaults (`minimap`, `ignoreList`) rather than aliasing the shared default.
+- **`global`** (account-wide) — every setting: `showWelcome`, `tooltipWarningEnabled`, `autoVendEnabled`, `autoVendMessagesEnabled`, `autoVendSummaryEnabled`, `bagsFullNudgeEnabled`, `bagsFullThreshold`, `safetyEnabled`, `safetyQuest`, `safetyConsumable`, `safetyWhite`, `safetyGray`, and `minimap` (the LibDBIcon placement table). Migration markers `autoVendSummaryMigrated` and `deleteMacroCleanupDone` also live here.
+- **`profile`** — only `ignoreLists`, a table keyed by character (`"Name - Realm"`); see *Per-Character State Inside a Shared Profile*.
+
+`## SavedVariablesPerCharacter: MagicEraserCharDB` is still declared in the TOC, but only as a legacy migration source — it is read once and cleared. The declaration is scheduled for removal after 2026-10-08 (see the MIGRATION comment in the TOC).
+
+Defaults come from `ns.DATABASE_DEFAULTS` and are applied lazily by AceDB-3.0 via metatables — nothing is copied into the saved table, and explicit user values (including `false`) are never overridden.
+
+There is no refill-on-empty logic: the curated item databases (`AllowedDeleteQuestItems`, `AllowedDeleteConsumables`, `AllowedDeleteEquipment`) are static Lua tables shipped in `Data/`, not saved variables, so they can never be emptied at runtime.
 
 ### Migration Chain
 
-- **`autoVendEnabled` (account → per-character)** — earlier versions stored `autoVendEnabled` on `MagicEraserDB`. On `PLAYER_LOGIN` the per-character field inherits the legacy account value when it is nil, then the legacy field is cleared. Only the first character to log in after the upgrade inherits it; later characters fall back to the default.
+All migrations run once in `ns:OnPlayerLogin`, guarded so they self-disable and are safe across every character:
 
-> `ApplyDefaults` runs *after* the migration; only fills nil fields; never overrides explicit user values.
+1. **Pre-AceDB adoption** *(remove after 2026-10-08)* — the pre-AceDB build kept two raw tables: account-wide `MagicEraserDB` (`showWelcome`, `minimap`, and on the oldest builds an account-level `autoVendEnabled`) and per-character `MagicEraserCharDB` (`autoVendEnabled`, `autoVendMessagesEnabled`, `ignoreList`). These are captured *before* AceDB adopts `MagicEraserDB`, folded into `global`, then the legacy keys are cleared. `autoVendEnabled` prefers the per-character value, falling back to the old account-level one.
+2. **Profile → global rehome** *(remove after 2026-10-11)* — the first AceDB build kept settings on one shared "Default" profile; a non-nil raw read for any settings key means the user set it, so it is moved up to `global` and cleared from the profile. Idempotent across toons.
+3. **Ignore-list flat reset** *(remove after 2026-10-11)* — those first AceDB builds also merged every toon's ignore list into a flat `profile.ignoreList`. That pollution can't be unmerged, so its mere presence zeroes every per-character bucket and deletes the flat list. Self-disabling once the flat list is gone.
+4. **Per-toon ignore seed** *(remove after 2026-10-11)* — this toon's bucket is seeded once, from its *own* pre-AceDB `MagicEraserCharDB.ignoreList` only, never the shared pool. A toon with no legacy list starts empty.
+5. **Auto-Vend message reset** *(remove after 2026-10-11)* — the Verbose/Summary rollout forces Auto-Vend messages on once for everyone via the `autoVendSummaryMigrated` marker, which has no default entry so AceDB never strips it and the reset cannot re-fire.
+6. **Stray macro cleanup** *(remove after 2026-10-11)* — the removed Delete Macro feature left an account-wide `- Eraser` macro; it is deleted once, combat-guarded (`DeleteMacro` is protected), and marked done only after a real pass.
+
+**Reset Profile.** `Reset Profile` in the AceDBOptions panel resets only the profile scope, which now holds just the ignore lists — so `ns:OnDatabaseReset` is hooked to the `OnProfileReset` callback to also restore every `global` setting to its default and re-show the minimap button, making the button behave like a full reset.
 
 ## Adding a New Trash Item
 
@@ -167,36 +212,51 @@ Defaults live in `ns.DEFAULT_CONFIGURATION` (`Data/Default-Settings.lua`) and ar
 - **Quest item** — append `[itemId] = { questId, ... }` to `Data/Quest-Items.lua`. List every quest that releases the item; the eraser fires when any of them is complete.
 - **Class reagent exclusion** — add to `ns.ClassReagentExclusions[CLASS_TOKEN]` in `Data/Data.lua`. Excluded items are never erased or vendored, regardless of database membership.
 
-Keep entries alphabetized by the trailing name comment so diffs stay readable. Per the style guide, arrays over 20 entries are appended to, never reformatted or reproduced wholesale, and each table carries a `-- TODO: Add SQL Query` marker until its originating Mangos query is filled in.
+Keep entries alphabetized by the trailing name comment so diffs stay readable. Per the style guide, these tables are appended to, never reformatted or reproduced wholesale, and each carries a `-- TODO: Add SQL Query` marker until its originating query is filled in — leave that marker in place.
 
-## Adding a New Locale
+## Adding a New Event
 
-Copy `Locales/enUS.lua` to `Locales/<locale>.lua`. Drop the `true` argument from `NewLocale("MagicEraser", "<locale>", true)` — that flag marks the default fallback, and only `enUS.lua` should set it. Translate every string. Add the file to `MagicEraser.toc` immediately after `Locales/enUS.lua`.
+1. Add the event name to `ns.EVENT_NAMES` in `Features/Core.lua`.
+2. Add a `EVENT_NAME = "OnXxx"` entry to `EVENT_HANDLERS` in the same file.
+3. Define `ns:OnXxx(...)` in whichever feature file owns it (Core, or a feature file loaded after Core — it is resolved by name at fire time).
 
-`esES.lua` and `esMX.lua` are separate standalone files, each with its own `NewLocale` call, like every other locale. Only `enUS.lua` is edited when strings change; the rest are translated separately, so a renamed key leaves harmless orphans in the other files until the next translation pass.
+That is the whole registration. The dispatcher, and the Diagnostic Tools event log and Event Registration probe, all read `ns.EVENT_NAMES`, so they pick the event up automatically with no second list to update. Never create a separate event frame — it would escape the diagnostics tap.
+
+## Localization
+
+WoW ships a fixed locale set, and every supported locale file already exists in `Locales/`, so localization here is **maintenance, not expansion** — there is no "add a new locale" step.
+
+- **Structure** — each `Locales/<locale>.lua` registers through `LibStub("AceLocale-3.0"):NewLocale("MagicEraser", "<locale>")`. `enUS.lua` is the source of truth and the only file that passes the `true` default-fallback flag; every string originates there.
+- **Keeping locales in sync** — every non-English file carries a translation of the same key set, and AceLocale falls back to English via `__index` for anything missing at runtime. Translating each `enUS.lua` key into every locale and keeping the files aligned is the job of the Localization pass; don't hand-edit the other locales during ordinary work. A renamed key leaves harmless orphans in the translated files until that pass runs.
+- **Placeholders** — `%s`/`%d` count, type, and order must match `enUS` per key in every locale, or the string crashes at runtime. This is the highest-value invariant when editing strings.
+- **Spanish** — `esES.lua` and `esMX.lua` are two separate, self-contained files; identical strings in both is correct and expected.
+- **Locale overflow** — German is the usual canary for length. Watch it wherever a translated string sits in a width-constrained slot — the minimap tooltip's double-lines and the options-panel toggle labels — since Magic Eraser generates no macros, the 255-character macro limit does not apply here.
 
 ## Common Pitfalls
 
-- **Cursor latency between pickup and delete**: `PickupContainerItem` is asynchronous. `RunEraser` verifies `GetCursorInfo` holds the expected `itemId` before `DeleteCursorItem`, printing `L["CURSOR_TOO_FAST"]` and clearing the cursor on a mismatch — a click-spam guard, not a real error.
+- **Cursor latency between pickup and delete**: `PickupContainerItem` is asynchronous. `PerformErase` verifies `GetCursorInfo` holds the expected `itemId` before `DeleteCursorItem`, printing `L["CURSOR_TOO_FAST"]` and clearing the cursor on a mismatch — a click-spam guard, not a real error.
 - **Stale `GetItemInfo` on first scan**: cold-cache nils are handled by `RequestLoadItemDataByID` plus the bounded retry. Don't add eager fallbacks like hyperlink parsing — let the API resolve.
-- **`BAG_UPDATE_DELAYED` fires per bag**: coalesce with the 0.1s `updatePending` guard already in `ns:OnBagUpdateDelayed`; don't refresh straight from the handler.
-- **Consumable eligibility is level-dependent**: `GetItemDeleteReason` reads `UnitLevel`, so the candidate must refresh on `PLAYER_LEVEL_UP` — a bag update is not guaranteed to fire after a ding.
+- **`BAG_UPDATE_DELAYED` fires repeatedly**: coalesce with the 0.1s `updatePending` guard already in `ns:OnBagUpdateDelayed`; don't refresh straight from the handler.
+- **Consumable eligibility is level-dependent**: `GetItemDeleteReason` reads `UnitLevel`, so the candidate must refresh on `PLAYER_LEVEL_UP` — a bag update is not guaranteed after a ding.
 - **Bypassing the dispatcher**: register events only by adding to `ns.EVENT_NAMES` plus an `ns:OnXxx` handler. A feature that creates its own event frame escapes the diagnostics event-log tap and goes unlogged.
 - **Auto-Vend and `sellPrice == 0`**: filtered at scan time. Quest items aren't vendorable, so the eraser keeps them rather than the vendor swallowing them.
 - **New Auto-Vend chat must use `PrintVendMessage`**: calling `ns:PrintMessage` directly from the vend path ignores the **Enable Auto-Vend Messages** toggle. Route every Auto-Vend line through the `PrintVendMessage` guard in `Auto-Vend.lua`.
+- **Settings are `global`, ignore lists are `profile`**: new user settings go in `ns.db.global` (account-wide) via a `ns.DATABASE_DEFAULTS.global` default; only the per-character ignore lists belong in `profile`. Putting a setting in `profile` silently makes it per-profile and breaks `Reset Profile` expectations.
+- **Server silently drops bulk sells**: don't assume one `ScanAndVend` pass clears the bags. The multi-pass loop (`MAX_VEND_PASSES`) exists because `UseContainerItem` sells are dropped under load; keep the re-scan-between-passes structure.
 
 ## Contributing
 
 Issues and PRs go on [GitHub](https://github.com/Gogo1951/Magic-Eraser/issues). Discussion happens on [Discord](https://discord.gg/eh8hKq992Q).
 
-Bug reports should include game version (Classic Era 1.15.x or TBC 2.5.x), locale, class + level, reproduction steps, and the relevant chat output. The Diagnostic Tools panel produces a copy-paste-ready report for exactly this.
+Bug reports should include game version (Classic Era 1.15.x or TBC Anniversary 2.5.x), locale, class + level, reproduction steps, and the relevant chat output. The Diagnostic Tools panel produces a copy-paste-ready report for exactly this.
 
 PR guidelines:
 
-- **One concern per PR.** A locale addition, a database expansion, and a logic change are three PRs.
+- **One concern per PR.** A locale update, a database expansion, and a logic change are three PRs.
 - **Match existing style** — 80-character section dividers, the `ns` namespace, `L["UPPER_SNAKE_CASE"]` for all user-facing strings, and the shared `ns.Options*` / `ns.GetColor` helpers.
-- **New saved-variable fields** seed defaults through `ns.DEFAULT_CONFIGURATION` + the `ApplyDefaults` merge; never overwrite user values.
-- **Database edits** keep the column-header comment and the SQL/`TODO` marker; don't reformat existing rows.
+- **New saved-variable fields** seed defaults through `ns.DATABASE_DEFAULTS` and rely on AceDB's metatable application; never hand-merge or overwrite user values.
+- **Database edits** keep the column-header comment and the `TODO` marker; don't reformat existing rows.
+- **Migration discipline** — migrations are one-time, guarded, and dated in `ns:OnPlayerLogin`; don't remove one before its noted date.
 - **Update this document** when the architecture or file map changes.
 - **Commit and PR descriptions require a User Story.** Don't just say "I changed X" or "I fixed Y" — frame the change by who it helps and why.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clean up your bags instantly. Completed quest items, low-level consumables, vend
 
 ## Setup
 
-1. **Install** from [CurseForge](https://www.curseforge.com/wow/addons/magic-eraser), [GitHub](https://github.com/Gogo1951/Magic-Eraser), or [Wago](https://addons.wago.io/addons/magic-eraser).
+1. Install the add-on, ideally using [CurseForge](https://www.curseforge.com/wow/addons/magic-eraser) or [Wago](https://addons.wago.io/addons/magic-eraser).
 2. Log in. The minimap button shows the icon of the lowest-value junk currently in your bags.
 3. Left-click to erase it, right-click to spare it, or Shift+Right-click to flip Auto-Vend on.
 4. Done — your bags now keep themselves clean. *"Cleanest bags on the server!"*
@@ -58,11 +58,11 @@ Find the panel at **Options > AddOns > Magic Eraser**. From there you can toggle
 
 🟢 World of Warcraft Classic (🟡 Season of Discovery) // WoW 1.15.8
 
-🟢 Burning Crusade Anniversary // WoW 2.5.5
+🟢 Burning Crusade Anniversary // WoW 2.5.6
 
-🔴 Mists of Pandaria Classic // WoW 5.5.3
+🔴 Mists of Pandaria Classic // WoW 5.5.4
 
-🔴 World of Warcraft // WoW 12.0.5
+🔴 World of Warcraft // WoW 12.1.0
 
 **Localization Status** // Works with all Classic WoW Locales (enUS, deDE, esES, esMX, frFR, itIT, koKR, ptBR, ruRU, zhCN, zhTW).
 


### PR DESCRIPTION
Fixed a bug with shared profiles, added a few other features like Eraser Safety toggles.

> I've been able to make those government-mandated upgrades you've all been suing me about. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added item tooltips showing whether an item will be erased or ignored.
  * Added configurable deletion safety confirmations by item type.
  * Added bag-space warnings, thresholds, and mailbox support.
  * Added Auto-Vend summary messages and expanded settings.
  * Added minimap clutter reports with reclaimable slots, items, and value.
  * Ignore lists are now maintained per character.

* **Documentation**
  * Updated installation, feature, configuration, and localization documentation.

* **Localization**
  * Expanded translations for new warnings, tooltips, options, and Auto-Vend summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->