### PR TITLE
Bug Fix

### DIFF
--- a/Features/Bag-Warnings.lua
+++ b/Features/Bag-Warnings.lua
@@ -6,6 +6,11 @@ local L = ns.L
 --------------------------------------------------------------------------------
 
 local GetContainerNumFreeSlots = C_Container.GetContainerNumFreeSlots
+local GetContainerNumSlots = C_Container.GetContainerNumSlots
+local GetTime = GetTime
+
+-- Blizzard's count of equippable bag slots; bag 0 is the backpack.
+local BAG_SLOTS = NUM_BAG_SLOTS or 4
 
 --------------------------------------------------------------------------------
 -- Bag-Space Warnings
@@ -18,23 +23,59 @@ local GetContainerNumFreeSlots = C_Container.GetContainerNumFreeSlots
     the countdown to one line per slot lost. Reset when free climbs back above the
     threshold so re-entering the warning zone warns again. Runtime-only.
 
-    Primed to the current free count at login via ns:SeedBagSpaceBaseline (called
-    from Core's OnPlayerLogin): the client fires a BAG_UPDATE_DELAYED burst as it
-    populates bags on load, and we don't want that to warn about bag space you
-    arrived with -- only about slots lost while playing. Seeding the baseline
-    makes the login burst a no-op (free is unchanged from the seed) so the first
-    real warning waits for a real change.
+    Primed at login to the free count we log in with via ns:SeedBagSpaceBaseline
+    (from Core's OnPlayerLogin), so the login-time BAG_UPDATE_DELAYED burst is
+    "already known" and does not warn about bag space you arrived with -- only a
+    slot lost while playing does.
 ]]
 local lastNudgeFree = nil
 
+--[[
+    Bag-space warnings stay quiet until GetTime() reaches this deadline, set on
+    every PLAYER_ENTERING_WORLD (see ns:OnEnteringWorld). Secondary to the
+    unknown-vs-zero guard in CountFreeSlots: it simply keeps the check idle for a
+    moment after each loading screen, while the client repopulates the containers.
+]]
+local BAG_SETTLE_SECONDS = 2
+local bagWarningsHeldUntil = 0
+
+--[[
+    Free general-purpose bag slots, or nil when the container API has no data yet.
+
+    Specialty bags -- soul bags, quivers, ammo pouches, profession bags -- are
+    excluded: ordinary loot can't go there, so their free slots are useless to
+    this warning. GogoLoot's Speedy-Loot budget is deliberately conservative in
+    exactly the same way.
+
+    The nil return is what fixes the reported bug. The shipped version summed
+    "(bagFree or 0)" for every bag, which silently turned "the API has no data
+    yet" into "this bag has zero free slots". Mid-loading-screen every container
+    reads nil, so the total came out 0 and printed "Your bags are full!" to a
+    player with 41 slots open -- and it repeated on every zone, because the
+    correct read in between (free > threshold) re-armed the dedup each time.
+    Reporting "unknown" instead lets the caller skip rather than cry full.
+
+    Readiness is judged from the data itself: the backpack always has slots and
+    always answers once the inventory is loaded, so a zero slot total, or no bag
+    answering at all, means nothing is loaded yet.
+]]
 local function CountFreeSlots()
-	local free = 0
-	for bag = 0, 4 do
-		-- Specialty bags (quiver, soul, profession) are excluded: ordinary loot can't go there.
+	local free, totalSlots, answered = 0, 0, 0
+	for bag = 0, BAG_SLOTS do
+		totalSlots = totalSlots + (GetContainerNumSlots(bag) or 0)
+
 		local bagFree, bagFamily = GetContainerNumFreeSlots(bag)
-		if (bagFamily or 0) == 0 then
-			free = free + (bagFree or 0)
+		-- 0 is truthy in Lua, so this rejects only a missing reading, never a full bag.
+		if bagFree then
+			answered = answered + 1
+			if bagFamily == 0 or bagFamily == nil then
+				free = free + bagFree
+			end
 		end
+	end
+
+	if totalSlots == 0 or answered == 0 then
+		return nil
 	end
 	return free
 end
@@ -53,13 +94,24 @@ function ns:IsBagWindowOpen()
 end
 
 --[[
-    Seed the bag-space warning baseline with the free count we log in with, so
-    the login-time BAG_UPDATE_DELAYED burst is treated as "already known" and
-    does not fire a warning on load -- only a slot lost while playing does. Called
-    from ns:OnPlayerLogin in Core.
+    Seed the bag-space warning baseline with the free count we log in with, so the
+    login-time BAG_UPDATE_DELAYED burst is treated as "already known" and does not
+    fire a warning on load -- only a slot lost while playing does. Called from
+    ns:OnPlayerLogin in Core. A nil count (containers not ready) simply leaves the
+    baseline armed, which is the same state we start in.
 ]]
 function ns:SeedBagSpaceBaseline()
 	lastNudgeFree = CountFreeSlots()
+end
+
+--[[
+    Hold the warning briefly on every PLAYER_ENTERING_WORLD -- loading-screen zone
+    change, initial login, or /reload -- so the container repopulation that
+    follows is never mistaken for slots lost in play. A fresh deadline each time
+    means rapid back-to-back loading screens just extend the hold.
+]]
+function ns:OnEnteringWorld()
+	bagWarningsHeldUntil = GetTime() + BAG_SETTLE_SECONDS
 end
 
 --[[
@@ -76,7 +128,17 @@ function ns:CheckBagsFullNudge()
 		return
 	end
 
+	-- Idle for a moment after each loading screen while the bags repopulate.
+	if GetTime() < bagWarningsHeldUntil then
+		return
+	end
+
 	local free = CountFreeSlots()
+	if not free then
+		-- Containers have no data yet: the answer is unknown, not full.
+		return
+	end
+
 	if free > ns.db.global.bagsFullThreshold then
 		lastNudgeFree = nil
 	elseif free ~= lastNudgeFree then

--- a/Features/Core.lua
+++ b/Features/Core.lua
@@ -99,6 +99,7 @@ end
 ]]
 ns.EVENT_NAMES = {
 	"PLAYER_LOGIN",
+	"PLAYER_ENTERING_WORLD",
 	"PLAYER_LEVEL_UP",
 	"BAG_UPDATE_DELAYED",
 	"QUEST_TURNED_IN",
@@ -110,6 +111,7 @@ ns.EVENT_NAMES = {
 
 local EVENT_HANDLERS = {
 	PLAYER_LOGIN = "OnPlayerLogin",
+	PLAYER_ENTERING_WORLD = "OnEnteringWorld",
 	PLAYER_LEVEL_UP = "OnPlayerLevelUp",
 	BAG_UPDATE_DELAYED = "OnBagUpdateDelayed",
 	QUEST_TURNED_IN = "OnQuestTurnedIn",

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -19,7 +19,12 @@ local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
 function ns:RegisterOptionsPanels()
 	AceConfig:RegisterOptionsTable(ns.OPTIONS_REGISTRY.General, ns.BuildGeneralOptions())
-	AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.General, ns.AddonTitle)
+	-- AddToBlizOptions returns (frame, categoryID). The ID is what Settings.OpenToCategory
+	-- expects; relying on the display name matching the ID is fragile -- the library only
+	-- aliases the ID to the name on clients without C_SettingsUtil.OpenSettingsPanel (Era),
+	-- so on TBC Anniversary a name-based lookup returns nil. Capture the real references here.
+	ns.GeneralPanel, ns.GeneralCategoryID =
+		AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.General, ns.AddonTitle)
 
 	local profilesOptions = ns.BuildProfilesOptions()
 	AceConfig:RegisterOptionsTable(ns.OPTIONS_REGISTRY.Profiles, profilesOptions)
@@ -34,16 +39,14 @@ end
 --------------------------------------------------------------------------------
 
 function ns:OpenOptionsPanel()
-	if Settings and Settings.GetCategory then
-		local category = Settings.GetCategory(ns.AddonTitle)
-		if category then
-			Settings.OpenToCategory(category.ID)
-			return
-		end
+	if Settings and Settings.OpenToCategory and ns.GeneralCategoryID then
+		Settings.OpenToCategory(ns.GeneralCategoryID)
+		return
 	end
-	if InterfaceOptionsFrame_OpenToCategory then
-		InterfaceOptionsFrame_OpenToCategory(ns.AddonTitle)
-		InterfaceOptionsFrame_OpenToCategory(ns.AddonTitle)
+	if InterfaceOptionsFrame_OpenToCategory and ns.GeneralPanel then
+		InterfaceOptionsFrame_OpenToCategory(ns.GeneralPanel)
+		-- Called twice for Classic compatibility.
+		InterfaceOptionsFrame_OpenToCategory(ns.GeneralPanel)
 		return
 	end
 	AceConfigDialog:Open(ns.OPTIONS_REGISTRY.General)


### PR DESCRIPTION
"Bags are full" bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bag-space warnings to accurately reflect available slots, including different bag configurations.
  * Prevented premature “bags full” notifications while bag data is still loading after login or entering the world.
  * Improved options-panel navigation across supported game versions.

* **Improvements**
  * Bag and mailbox checks now handle unavailable inventory data more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->